### PR TITLE
Set ECC key RNG in we_ec_init.

### DIFF
--- a/wolfengine.c
+++ b/wolfengine.c
@@ -1185,6 +1185,11 @@ static int we_ec_init(EVP_PKEY_CTX *ctx)
     if (ret == 1) {
         ret = wc_ecc_init(&ecc->key) == 0;
     }
+#ifndef HAVE_FIPS_VERSION
+    if (ret == 1) {
+        ret = wc_ecc_set_rng(&ecc->key, &we_globalRng) == 0;
+    }
+#endif /* HAVE_FIPS_VERSION */
     if (ret == 1) {
         EVP_PKEY_CTX_set_data(ctx, ecc);
     }
@@ -1901,6 +1906,11 @@ static int we_ec_key_compute_key(unsigned char **psec, size_t *pseclen,
     if (ret == 1) {
         ret = wc_ecc_init(&key) == 0;
     }
+#ifndef HAVE_FIPS_VERSION
+    if (ret == 1) {
+        ret = wc_ecc_set_rng(&key, &we_globalRng) == 0;
+    }
+#endif /* HAVE_FIPS_VERSION */
     if (ret == 1) {
         pKey = &key;
 


### PR DESCRIPTION
This fixes some unit tests that were failing because there was no RNG associated
with the ECC key.