### PR TITLE
Log control command number when unsupported.

### DIFF
--- a/src/aes_block.c
+++ b/src/aes_block.c
@@ -429,6 +429,7 @@ static int we_aes_cbc_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
 {
     int ret = 1;
     we_AesBlock *aes;
+    char errBuff[WOLFENGINE_MAX_ERROR_SZ];
 
     WOLFENGINE_ENTER("we_aes_cbc_ctrl");
 
@@ -444,7 +445,9 @@ static int we_aes_cbc_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
     if (ret == 1) {
         switch (type) {
             default:
-                WOLFENGINE_ERROR_MSG("Unsupported ctrl type");
+                XSNPRINTF(errBuff, sizeof(errBuff), "Unsupported ctrl type %d",
+                          type);
+                WOLFENGINE_ERROR_MSG(errBuff);
                 ret = 0;
                 break;
         }
@@ -951,6 +954,7 @@ static int we_aes_ecb_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
 {
     int ret = 1;
     we_AesBlock *aes;
+    char errBuff[WOLFENGINE_MAX_ERROR_SZ];
 
     WOLFENGINE_ENTER("we_aes_ecb_ctrl");
 
@@ -966,7 +970,9 @@ static int we_aes_ecb_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
     if (ret == 1) {
         switch (type) {
             default:
-                WOLFENGINE_ERROR_MSG("Unsupported ctrl type");
+                XSNPRINTF(errBuff, sizeof(errBuff), "Unsupported ctrl type %d",
+                          type);
+                WOLFENGINE_ERROR_MSG(errBuff);
                 ret = 0;
                 break;
         }

--- a/src/aes_cbc_hmac.c
+++ b/src/aes_cbc_hmac.c
@@ -372,6 +372,7 @@ static int we_aes_cbc_hmac_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg,
     unsigned char *tls;
     int tlsVer;
     int len;
+    char errBuff[WOLFENGINE_MAX_ERROR_SZ];
 
     WOLFENGINE_ENTER("we_aes_cbc_hmac_ctrl");
 
@@ -446,7 +447,9 @@ static int we_aes_cbc_hmac_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg,
                 }
                 break;
             default:
-                WOLFENGINE_ERROR_MSG("Unsupported ctrl type");
+                XSNPRINTF(errBuff, sizeof(errBuff), "Unsupported ctrl type %d",
+                          type);
+                WOLFENGINE_ERROR_MSG(errBuff);
                 ret = 0;
                 break;
         }

--- a/src/aes_ccm.c
+++ b/src/aes_ccm.c
@@ -365,6 +365,7 @@ static int we_aes_ccm_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
 {
     int ret = 1;
     we_AesCcm *aes;
+    char errBuff[WOLFENGINE_MAX_ERROR_SZ];
 
     WOLFENGINE_ENTER("we_aes_ccm_ctrl");
 
@@ -502,7 +503,9 @@ static int we_aes_ccm_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
                 break;
 
             default:
-                WOLFENGINE_ERROR_MSG("Unsopported ctrl type");
+                XSNPRINTF(errBuff, sizeof(errBuff), "Unsupported ctrl type %d",
+                          type);
+                WOLFENGINE_ERROR_MSG(errBuff);
                 ret = 0;
                 break;
         }

--- a/src/aes_ctr.c
+++ b/src/aes_ctr.c
@@ -155,6 +155,7 @@ static int we_aes_ctr_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
 {
     int ret = 1;
     we_AesCtr *aes;
+    char errBuff[WOLFENGINE_MAX_ERROR_SZ];
 
     WOLFENGINE_ENTER("we_aes_ctr_ctrl");
 
@@ -170,7 +171,9 @@ static int we_aes_ctr_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
     if (ret == 1) {
         switch (type) {
             default:
-                WOLFENGINE_ERROR_MSG("Unsupported ctrl type");
+                XSNPRINTF(errBuff, sizeof(errBuff), "Unsupported ctrl type %d",
+                          type);
+                WOLFENGINE_ERROR_MSG(errBuff);
                 ret = 0;
                 break;
         }

--- a/src/aes_gcm.c
+++ b/src/aes_gcm.c
@@ -317,6 +317,7 @@ static int we_aes_gcm_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
     int ret = 1;
     int rc;
     we_AesGcm *aes;
+    char errBuff[WOLFENGINE_MAX_ERROR_SZ];
 
     WOLFENGINE_ENTER("we_aes_gcm_ctrl");
 
@@ -508,7 +509,9 @@ static int we_aes_gcm_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
                 break;
 
             default:
-                WOLFENGINE_ERROR_MSG("Unsopported ctrl type");
+                XSNPRINTF(errBuff, sizeof(errBuff), "Unsupported ctrl type %d",
+                          type);
+                WOLFENGINE_ERROR_MSG(errBuff);
                 ret = 0;
                 break;
         }

--- a/src/des3_cbc.c
+++ b/src/des3_cbc.c
@@ -425,6 +425,7 @@ static int we_des3_cbc_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
 {
     int ret = 1;
     we_Des3Cbc *des3;
+    char errBuff[WOLFENGINE_MAX_ERROR_SZ];
 
     WOLFENGINE_ENTER("we_des3_cbc_ctrl");
 
@@ -440,7 +441,9 @@ static int we_des3_cbc_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
     if (ret == 1) {
         switch (type) {
             default:
-                WOLFENGINE_ERROR_MSG("Unsupported ctrl type");
+                XSNPRINTF(errBuff, sizeof(errBuff), "Unsupported ctrl type %d",
+                          type);
+                WOLFENGINE_ERROR_MSG(errBuff);
                 ret = 0;
                 break;
         }

--- a/src/ecc.c
+++ b/src/ecc.c
@@ -776,6 +776,7 @@ static int we_ec_ctrl(EVP_PKEY_CTX *ctx, int type, int num, void *ptr)
     EVP_PKEY *peerKey;
     EC_KEY *ecPeerKey = NULL;
 #endif
+    char errBuff[WOLFENGINE_MAX_ERROR_SZ];
 
     (void)num;
     (void)ptr;
@@ -847,7 +848,9 @@ static int we_ec_ctrl(EVP_PKEY_CTX *ctx, int type, int num, void *ptr)
 
             /* Unsupported type. */
             default:
-                WOLFENGINE_ERROR_MSG("Unsupported control command type");
+                XSNPRINTF(errBuff, sizeof(errBuff), "Unsupported ctrl type %d",
+                          type);
+                WOLFENGINE_ERROR_MSG(errBuff);
                 ret = 0;
                 break;
         }

--- a/src/internal.c
+++ b/src/internal.c
@@ -813,6 +813,7 @@ static int wolfengine_ctrl(ENGINE* e, int cmd, long i, void* p,
                            void (*f) (void))
 {
     int ret = 1;
+    char errBuff[WOLFENGINE_MAX_ERROR_SZ];
 
     (void)e;
     (void)p;
@@ -845,7 +846,9 @@ static int wolfengine_ctrl(ENGINE* e, int cmd, long i, void* p,
             }
             break;
         default:
-            WOLFENGINE_ERROR_MSG("Invalid wolfEngine control command");
+            XSNPRINTF(errBuff, sizeof(errBuff), "Unsupported ctrl type %d",
+                      cmd);
+            WOLFENGINE_ERROR_MSG(errBuff);
             ret = 0;
     }
 

--- a/src/rsa.c
+++ b/src/rsa.c
@@ -770,6 +770,7 @@ static int we_rsa_pkey_ctrl(EVP_PKEY_CTX *ctx, int type, int num, void *ptr)
     we_Rsa *rsa = NULL;
     BIGNUM* bn = NULL;
     long e;
+    char errBuff[WOLFENGINE_MAX_ERROR_SZ];
 
     WOLFENGINE_ENTER("we_rsa_pkey_ctrl");
 
@@ -829,6 +830,9 @@ static int we_rsa_pkey_ctrl(EVP_PKEY_CTX *ctx, int type, int num, void *ptr)
                 }
                 break;
             default:
+                XSNPRINTF(errBuff, sizeof(errBuff), "Unsupported ctrl type %d",
+                          type);
+                WOLFENGINE_ERROR_MSG(errBuff);
                 ret = 0;
                 break;
         }


### PR DESCRIPTION
This should help us figure out what exact command is missing when we/the customer encounter an unsupported control command at runtime.