### PR TITLE
Adds ECC P-521 support for EVP_PKEY

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -449,6 +449,17 @@ then
     AM_CFLAGS="$AM_CFLAGS -DWE_HAVE_EC_P384"
 fi
 
+AC_ARG_ENABLE([p521],
+    [AS_HELP_STRING([--enable-p521],[Enable EC Curve P-521 (default: enabled)])],
+    [ ENABLED_EC_P521=$enableval ],
+    [ ENABLED_EC_P521=$ENABLED_ECC ]
+    )
+
+if test "$ENABLED_EC_P521" = "yes"
+then
+    AM_CFLAGS="$AM_CFLAGS -DWE_HAVE_EC_P521"
+fi
+
 
 # Check enable options
 if test "$ENABLED_DIGEST" = "yes"
@@ -547,6 +558,7 @@ echo "   *  - EC Key Gen:              $ENABLED_ECKG"
 echo "   *  - ECDH:                    $ENABLED_ECDH"
 echo "   *  - P-256:                   $ENABLED_EC_P256"
 echo "   *  - P-384:                   $ENABLED_EC_P384"
+echo "   *  - P-521:                   $ENABLED_EC_P521"
 echo ""
 echo "---"
 

--- a/include/internal.h
+++ b/include/internal.h
@@ -165,6 +165,7 @@ extern EC_KEY_METHOD *we_ec_key_method;
 extern EVP_PKEY_METHOD *we_ec_method;
 extern EVP_PKEY_METHOD *we_ec_p256_method;
 extern EVP_PKEY_METHOD *we_ec_p384_method;
+extern EVP_PKEY_METHOD *we_ec_p521_method;
 int we_init_ecc_meths(void);
 int we_init_ec_key_meths(void);
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -37,6 +37,9 @@ static const int we_pkey_nids[] = {
 #ifdef WE_HAVE_EC_P384
     NID_secp384r1,
 #endif
+#ifdef WE_HAVE_EC_P521
+    NID_secp521r1,
+#endif
 #endif
 #endif
 };
@@ -480,7 +483,12 @@ static int we_pkey(ENGINE *e, EVP_PKEY_METHOD **pkey, const int **nids,
         case NID_secp384r1:
             *pkey = we_ec_p384_method;
             break;
-#endif 
+#endif
+#ifdef WE_HAVE_EC_P521
+        case NID_secp521r1:
+            *pkey = we_ec_p521_method;
+            break;
+#endif
 #endif /* WE_HAVE_ECKEYGEN */
         default:
             WOLFENGINE_ERROR_MSG("Unsupported public key NID");

--- a/test/test_ecc.c
+++ b/test/test_ecc.c
@@ -63,6 +63,34 @@ static const unsigned char ecc_key_der_384[] = {
     0x35, 0x25, 0xE1, 0x90, 0x3B, 0x86, 0xE0
 };
 #endif /* WE_HAVE_EC_P384 */
+
+#ifdef WE_HAVE_EC_P521
+static const unsigned char ecc_key_der_521[] = {
+    0x30, 0x81, 0xDC, 0x02, 0x01, 0x01, 0x04, 0x42, 0x01, 0x20,
+    0x39, 0x65, 0x17, 0x39, 0xC7, 0xD5, 0x51, 0x2C, 0x38, 0x28,
+    0x71, 0x44, 0xBC, 0x74, 0x65, 0x1F, 0x0F, 0x22, 0xEA, 0xF4,
+    0xF4, 0xC0, 0xC0, 0xB6, 0x42, 0x6B, 0xF1, 0x8B, 0x59, 0xCF,
+    0x9A, 0x0F, 0x99, 0x57, 0x9F, 0x64, 0x2F, 0x2C, 0x7A, 0x55,
+    0xDA, 0x11, 0x7F, 0x07, 0xC9, 0x2A, 0x6B, 0xD4, 0x50, 0x67,
+    0x17, 0x1E, 0x4A, 0x48, 0x5D, 0xD6, 0xEA, 0x94, 0x3A, 0x3C,
+    0x17, 0x95, 0x22, 0x07, 0xA0, 0x07, 0x06, 0x05, 0x2B, 0x81,
+    0x04, 0x00, 0x23, 0xA1, 0x81, 0x89, 0x03, 0x81, 0x86, 0x00,
+    0x04, 0x01, 0x87, 0x6D, 0xF1, 0x43, 0x50, 0xB8, 0xA8, 0xD9,
+    0x6F, 0x70, 0xBB, 0x0A, 0xEB, 0x42, 0x2B, 0xCE, 0x31, 0x33,
+    0xF6, 0x15, 0xD0, 0xD5, 0x95, 0x42, 0x44, 0x87, 0xF1, 0x3D,
+    0xB7, 0x5F, 0x17, 0x69, 0xBE, 0xEF, 0xDF, 0x8D, 0xB7, 0xCF,
+    0x73, 0xAA, 0xF3, 0x34, 0xD1, 0xEA, 0xEA, 0x1B, 0x74, 0xCC,
+    0x64, 0x12, 0x17, 0xEF, 0x56, 0x77, 0xED, 0xC0, 0x83, 0xF9,
+    0xA8, 0x1F, 0x4C, 0x01, 0xC5, 0x05, 0x7A, 0x01, 0x31, 0xF6,
+    0x84, 0xAB, 0x6A, 0xB8, 0x9B, 0x94, 0xFB, 0xFE, 0x42, 0xAF,
+    0x50, 0x46, 0x8B, 0x00, 0x8F, 0xE2, 0xB1, 0x94, 0xB8, 0xC2,
+    0xFF, 0x57, 0x2D, 0x90, 0x77, 0xB5, 0x09, 0x9A, 0x36, 0xEB,
+    0x14, 0xB8, 0x5B, 0x89, 0x73, 0xA9, 0x8C, 0x0B, 0x04, 0xB4,
+    0xDC, 0xDF, 0xA7, 0x3B, 0x60, 0xD6, 0x8E, 0x89, 0x0C, 0xCB,
+    0x48, 0x4B, 0xB0, 0xDC, 0x0B, 0x9E, 0x31, 0x44, 0x58, 0x54,
+    0x2D, 0xF4, 0x15
+};
+#endif /* WE_HAVE_EC_P521 */
 #endif /* WE_HAVE_ECDSA || WE_HAVE_ECDH */
 #ifdef WE_HAVE_ECDH
 #ifdef WE_HAVE_EC_P256
@@ -117,6 +145,44 @@ static const unsigned char ecc_derived_384[] = {
     0x42, 0xed, 0x89, 0xdf, 0x7e, 0x24, 0xfd, 0xaf, 0x47, 0x94,
     0x6c, 0xab, 0x0f, 0x7f, 0x60, 0x3e, 0xc4, 0xc8, 0xf3, 0x0e,
     0xd1, 0x73, 0x7d, 0x3a, 0x11, 0x91, 0x6e, 0x3c
+};
+#endif /* WE_HAVE_EC_P384 */
+
+#ifdef WE_HAVE_EC_P521
+static const unsigned char ecc_peerkey_der_521[] = {
+    0x30, 0x81, 0xDC, 0x02, 0x01, 0x01, 0x04, 0x42, 0x00, 0x17,
+    0xD2, 0x97, 0xF9, 0xBE, 0x0E, 0x1A, 0xF3, 0x1A, 0x36, 0xC0,
+    0xAE, 0x24, 0xFD, 0x96, 0x35, 0x31, 0x21, 0xD4, 0xB1, 0x95,
+    0x1B, 0xA8, 0x9E, 0x1D, 0xB0, 0xA6, 0x54, 0x4B, 0x3D, 0x33,
+    0x76, 0x88, 0x9A, 0x4C, 0x1A, 0x8B, 0xEC, 0x96, 0x7E, 0xEC,
+    0x4E, 0xC8, 0xC9, 0xDE, 0x7B, 0xCA, 0x0D, 0x87, 0x92, 0xD2,
+    0xA9, 0x3F, 0x19, 0xA5, 0x31, 0x34, 0x6E, 0xD1, 0x6F, 0x1B,
+    0x46, 0x9A, 0x6F, 0x00, 0xA0, 0x07, 0x06, 0x05, 0x2B, 0x81,
+    0x04, 0x00, 0x23, 0xA1, 0x81, 0x89, 0x03, 0x81, 0x86, 0x00,
+    0x04, 0x00, 0x71, 0x53, 0x4C, 0x65, 0x53, 0xEA, 0xD4, 0x4A,
+    0x5F, 0x47, 0xD6, 0x48, 0xBA, 0xED, 0x1C, 0xC6, 0xF6, 0xC3,
+    0xF0, 0x3E, 0x22, 0xB6, 0x3C, 0x84, 0x6A, 0xF6, 0xE4, 0x22,
+    0x64, 0xF0, 0xFB, 0xF2, 0xB3, 0xAD, 0x99, 0x31, 0x45, 0x2C,
+    0xC4, 0x1A, 0x18, 0xF6, 0x97, 0xCD, 0x22, 0xDA, 0xD3, 0xAA,
+    0x3F, 0x64, 0x8C, 0x2C, 0xAE, 0x87, 0xE3, 0xE0, 0xD7, 0xE8,
+    0x41, 0x05, 0x84, 0xA0, 0xDE, 0x0C, 0xD8, 0x00, 0x3B, 0x6F,
+    0x2B, 0x94, 0x8F, 0x75, 0xC1, 0x39, 0x93, 0xDE, 0xD9, 0xB7,
+    0x6D, 0x45, 0x6C, 0xDE, 0xCA, 0xCB, 0x65, 0x6E, 0xBA, 0x60,
+    0x3F, 0x36, 0x70, 0xD1, 0x08, 0x28, 0x86, 0x49, 0x7F, 0x79,
+    0x17, 0x57, 0x7B, 0x71, 0x2F, 0xCB, 0xB2, 0x3C, 0xBA, 0xE1,
+    0xFF, 0xAA, 0x27, 0x29, 0xB7, 0x70, 0x2F, 0x4E, 0x32, 0x4B,
+    0x86, 0xE7, 0x38, 0x66, 0x7B, 0xA5, 0x48, 0xB1, 0xA0, 0x08,
+    0xD4, 0x20, 0x9A
+};
+
+static const unsigned char ecc_derived_521[] = {
+    0x00, 0xD6, 0x7C, 0x04, 0xAC, 0xF7, 0x70, 0x65, 0x82, 0xA5,
+    0x34, 0x87, 0x67, 0x23, 0x5F, 0xD5, 0xD0, 0x1F, 0x7F, 0x28,
+    0x3B, 0xF3, 0x01, 0xBE, 0x77, 0x0F, 0x50, 0x73, 0xF3, 0x6E,
+    0x70, 0x4D, 0xC6, 0x35, 0x0D, 0x8D, 0xBA, 0xC2, 0x8C, 0x37,
+    0xA0, 0x79, 0x49, 0x54, 0xBF, 0x52, 0xCA, 0xF4, 0x60, 0x2B,
+    0xC2, 0xCD, 0x3E, 0xED, 0xDA, 0x5F, 0xB5, 0xFE, 0x53, 0xDD,
+    0x1A, 0xA5, 0xDB, 0x71, 0x4A, 0xCD
 };
 #endif /* WE_HAVE_EC_P384 */
 #endif /* WE_HAVE_ECDH */
@@ -238,6 +304,62 @@ int test_eckeygen_p384(ENGINE *e, void *data)
 }
 #endif /* WE_HAVE_EC_P384 */
 
+#ifdef WE_HAVE_EC_P521
+int test_eckeygen_p521_by_nid(ENGINE *e, void *data)
+{
+    int err;
+    EVP_PKEY_CTX *ctx = NULL;
+    EVP_PKEY *key = NULL;
+
+    (void)data;
+
+    PRINT_MSG("Create P-521 public key context");
+    err = (ctx = EVP_PKEY_CTX_new_id(NID_secp521r1, e)) == NULL;
+    if (err == 0) {
+        PRINT_MSG("Initialize key generation");
+        err = EVP_PKEY_keygen_init(ctx) != 1;
+    }
+    if (err == 0) {
+        PRINT_MSG("Generate key");
+        err = EVP_PKEY_keygen(ctx, &key) != 1;
+    }
+
+    EVP_PKEY_free(key);
+    EVP_PKEY_CTX_free(ctx);
+
+    return err;
+}
+
+int test_eckeygen_p521(ENGINE *e, void *data)
+{
+    int err;
+    EVP_PKEY_CTX *ctx = NULL;
+    EVP_PKEY *key = NULL;
+
+    (void)data;
+
+    PRINT_MSG("Create public key context");
+    err = (ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_EC, e)) == NULL;
+    if (err == 0) {
+        PRINT_MSG("Initialize key generation");
+        err = EVP_PKEY_keygen_init(ctx) != 1;
+    }
+    if (err == 0) {
+        PRINT_MSG("Set named curve NID");
+        err = EVP_PKEY_CTX_set_ec_paramgen_curve_nid(ctx, NID_secp521r1) != 1;
+    }
+    if (err == 0) {
+        PRINT_MSG("Generate key");
+        err = EVP_PKEY_keygen(ctx, &key) != 1;
+    }
+
+    EVP_PKEY_free(key);
+    EVP_PKEY_CTX_free(ctx);
+
+    return err;
+}
+#endif /* WE_HAVE_EC_P521 */
+
 #endif /* WE_HAVE_ECKEYGEN */
 
 #ifdef WE_HAVE_ECDH
@@ -353,6 +475,15 @@ int test_ecdh_p384_keygen(ENGINE *e, void *data)
     return test_ecdh_keygen(e, NID_secp384r1, 48);
 }
 #endif /* WE_HAVE_EC_P384 */
+
+#ifdef WE_HAVE_EC_P521
+int test_ecdh_p521_keygen(ENGINE *e, void *data)
+{
+    (void)data;
+
+    return test_ecdh_keygen(e, NID_secp521r1, 66);
+}
+#endif /* WE_HAVE_EC_P521 */
 #endif /* WE_HAVE_ECKEYGEN */
 
 int test_ecdh(ENGINE *e, const unsigned char *privKey, size_t len,
@@ -425,6 +556,16 @@ int test_ecdh_p384(ENGINE *e, void *data)
                      ecc_derived_384, sizeof(ecc_derived_384));
 }
 #endif /* WE_HAVE_EC_P384 */
+
+#ifdef WE_HAVE_EC_P521
+int test_ecdh_p521(ENGINE *e, void *data)
+{
+    (void)data;
+    return test_ecdh(e, ecc_key_der_521, sizeof(ecc_key_der_521),
+                     ecc_peerkey_der_521, sizeof(ecc_peerkey_der_521),
+                     ecc_derived_521, sizeof(ecc_derived_521));
+}
+#endif /* WE_HAVE_EC_P521 */
 
 #endif /* WE_HAVE_ECDH */
 
@@ -501,6 +642,61 @@ int test_ecdsa_p384_pkey(ENGINE *e, void *data)
     err = RAND_bytes(buf, sizeof(buf)) == 0;
     if (err == 0) {
         pkey = d2i_PrivateKey(EVP_PKEY_EC, NULL, &p, sizeof(ecc_key_der_384));
+        err = pkey == NULL;
+    }
+    if (err == 0) {
+        PRINT_MSG("Sign with OpenSSL");
+        ecdsaSigLen = sizeof(ecdsaSig);
+        err = test_pkey_sign(pkey, NULL, buf, sizeof(buf), ecdsaSig,
+                                   &ecdsaSigLen);
+    }
+    if (err == 0) {
+        PRINT_MSG("Verify with wolfengine");
+        err = test_pkey_verify(pkey, e, buf, sizeof(buf), ecdsaSig,
+                                     ecdsaSigLen);
+    }
+    if (err == 0) {
+        PRINT_MSG("Verify bad signature with wolfengine");
+        ecdsaSig[1] ^= 0x80;
+        res = test_pkey_verify(pkey, e, buf, sizeof(buf), ecdsaSig,
+                                     ecdsaSigLen);
+        if (res != 1)
+            err = 1;
+    }
+    if (err == 0) {
+        PRINT_MSG("Sign with wolfengine");
+        ecdsaSigLen = sizeof(ecdsaSig);
+        err = test_pkey_sign(pkey, e, buf, sizeof(buf), ecdsaSig,
+                                   &ecdsaSigLen);
+    }
+    if (err == 0) {
+        PRINT_MSG("Verify with OpenSSL");
+        err = test_pkey_verify(pkey, NULL, buf, sizeof(buf),
+                                     ecdsaSig, ecdsaSigLen);
+    }
+
+    EVP_PKEY_free(pkey);
+
+    return err;
+}
+#endif /* WE_HAVE_EC_P384 */
+
+#ifdef WE_HAVE_EC_P521
+int test_ecdsa_p521_pkey(ENGINE *e, void *data)
+{
+    int err;
+    int res;
+    EVP_PKEY *pkey = NULL;
+    unsigned char ecdsaSig[163];
+    size_t ecdsaSigLen;
+    unsigned char buf[20];
+    const unsigned char *p = ecc_key_der_521;
+
+    (void)data;
+
+    err = RAND_bytes(buf, sizeof(buf)) == 0;
+    if (err == 0) {
+        pkey = d2i_PrivateKey(EVP_PKEY_EC, NULL, &p, sizeof(ecc_key_der_521));
         err = pkey == NULL;
     }
     if (err == 0) {
@@ -650,6 +846,61 @@ int test_ecdsa_p384(ENGINE *e, void *data)
 }
 #endif /* WE_HAVE_EC_P384 */
 
+#ifdef WE_HAVE_EC_P521
+int test_ecdsa_p521(ENGINE *e, void *data)
+{
+    int err;
+    int res;
+    EVP_PKEY *pkey = NULL;
+    unsigned char ecdsaSig[163];
+    size_t ecdsaSigLen;
+    unsigned char buf[128];
+    const unsigned char *p = ecc_key_der_521;
+
+    (void)data;
+
+    err = RAND_bytes(buf, sizeof(buf)) == 0;
+    if (err == 0) {
+        pkey = d2i_PrivateKey(EVP_PKEY_EC, NULL, &p, sizeof(ecc_key_der_521));
+        err = pkey == NULL;
+    }
+    if (err == 0) {
+        PRINT_MSG("Sign with OpenSSL");
+        ecdsaSigLen = sizeof(ecdsaSig);
+        err = test_digest_sign(pkey, NULL, buf, sizeof(buf), EVP_sha512(),
+                              ecdsaSig, &ecdsaSigLen);
+    }
+    if (err == 0) {
+        PRINT_MSG("Verify with wolfengine");
+        err = test_digest_verify(pkey, e, buf, sizeof(buf), EVP_sha512(),
+                                ecdsaSig, ecdsaSigLen);
+    }
+    if (err == 0) {
+        PRINT_MSG("Verify bad signature with wolfengine");
+        ecdsaSig[1] ^= 0x80;
+        res = test_digest_verify(pkey, e, buf, sizeof(buf), EVP_sha512(),
+                                ecdsaSig, ecdsaSigLen);
+        if (res != 1)
+            err = 1;
+    }
+    if (err == 0) {
+        PRINT_MSG("Sign with wolfengine");
+        ecdsaSigLen = sizeof(ecdsaSig);
+        err = test_digest_sign(pkey, e, buf, sizeof(buf), EVP_sha512(),
+                              ecdsaSig, &ecdsaSigLen);
+    }
+    if (err == 0) {
+        PRINT_MSG("Verify with OpenSSL");
+        err = test_digest_verify(pkey, NULL, buf, sizeof(buf), EVP_sha512(),
+                                ecdsaSig, ecdsaSigLen);
+    }
+
+    EVP_PKEY_free(pkey);
+
+    return err;
+}
+#endif /* WE_HAVE_EC_P521 */
+
 #endif /* WE_HAVE_ECDSA */
 
 #endif /* WE_HAVE_EVP_PKEY */
@@ -701,6 +952,14 @@ int test_ec_key_keygen_p384_by_nid(ENGINE *e, void *data)
 }
 #endif /* WE_HAVE_EC_P384 */
 
+#ifdef WE_HAVE_EC_P521
+int test_ec_key_keygen_p521_by_nid(ENGINE *e, void *data)
+{
+    (void)data;
+    return test_ec_key_keygen_by_nid(e, NID_secp521r1);
+}
+#endif /* WE_HAVE_EC_P521 */
+
 #endif /* WE_HAVE_ECKEYGEN */
 
 #ifdef WE_HAVE_ECDH
@@ -714,8 +973,8 @@ int test_ec_key_ecdh_keygen(ENGINE *e, int nid, int len)
     EC_KEY *keyB = NULL;
     const EC_POINT *pubKeyA;
     const EC_POINT *pubKeyB;
-    unsigned char secretA[48];
-    unsigned char secretB[48];
+    unsigned char secretA[66];
+    unsigned char secretB[66];
 
     err = (group = EC_GROUP_new_by_curve_name(nid)) == NULL;
     if (err == 0) {
@@ -783,6 +1042,15 @@ int test_ec_key_ecdh_p384_keygen(ENGINE *e, void *data)
     return test_ec_key_ecdh_keygen(e, NID_secp384r1, 48);
 }
 #endif /* WE_HAVE_EC_P384 */
+
+#ifdef WE_HAVE_EC_P521
+int test_ec_key_ecdh_p521_keygen(ENGINE *e, void *data)
+{
+    (void)data;
+
+    return test_ec_key_ecdh_keygen(e, NID_secp521r1, 66);
+}
+#endif /* WE_HAVE_EC_P521 */
 #endif /* WE_HAVE_ECKEYGEN */
 
 int test_ec_key_ecdh(ENGINE *e, const unsigned char *privKey, size_t len,
@@ -794,8 +1062,8 @@ int test_ec_key_ecdh(ENGINE *e, const unsigned char *privKey, size_t len,
     EC_KEY *keyB = NULL;
     const EC_POINT *pubKeyA;
     const EC_POINT *pubKeyB;
-    unsigned char secretA[48];
-    unsigned char secretB[48];
+    unsigned char secretA[66];
+    unsigned char secretB[66];
     const unsigned char *p;
 
     err = (keyA = EC_KEY_new_method(e)) == NULL;
@@ -864,6 +1132,16 @@ int test_ec_key_ecdh_p384(ENGINE *e, void *data)
                             ecc_derived_384, sizeof(ecc_derived_384));
 }
 #endif /* WE_HAVE_EC_P384 */
+
+#ifdef WE_HAVE_EC_P521
+int test_ec_key_ecdh_p521(ENGINE *e, void *data)
+{
+    (void)data;
+    return test_ec_key_ecdh(e, ecc_key_der_521, sizeof(ecc_key_der_521),
+                            ecc_peerkey_der_521, sizeof(ecc_peerkey_der_521),
+                            ecc_derived_521, sizeof(ecc_derived_521));
+}
+#endif /* WE_HAVE_EC_P521 */
 
 #endif /* WE_HAVE_ECDH */
 
@@ -1000,6 +1278,14 @@ int test_ec_key_ecdsa_p384(ENGINE *e, void *data)
     return test_ec_key_ecdsa(e, ecc_key_der_384, sizeof(ecc_key_der_384));
 }
 #endif /* WE_HAVE_EC_P384 */
+
+#ifdef WE_HAVE_EC_P521
+int test_ec_key_ecdsa_p521(ENGINE *e, void *data)
+{
+    (void)data;
+    return test_ec_key_ecdsa(e, ecc_key_der_521, sizeof(ecc_key_der_521));
+}
+#endif /* WE_HAVE_EC_P521 */
 
 #endif /* WE_HAVE_ECDSA */
 

--- a/test/unit.c
+++ b/test/unit.c
@@ -157,6 +157,22 @@ TEST_CASE test_case[] = {
         TEST_DECL(test_ecdsa_p384, NULL),
     #endif
 #endif
+#ifdef WE_HAVE_EC_P521
+    #ifdef WE_HAVE_ECKEYGEN
+        TEST_DECL(test_eckeygen_p521_by_nid, NULL),
+        TEST_DECL(test_eckeygen_p521, NULL),
+    #endif
+    #ifdef WE_HAVE_ECDH
+    #ifdef WE_HAVE_ECKEYGEN
+        TEST_DECL(test_ecdh_p521_keygen, NULL),
+    #endif
+        TEST_DECL(test_ecdh_p521, NULL),
+    #endif
+    #ifdef WE_HAVE_ECDSA
+        TEST_DECL(test_ecdsa_p521_pkey, NULL),
+        TEST_DECL(test_ecdsa_p521, NULL),
+    #endif
+#endif
 #endif /* WE_HAVE_EVP_PKEY */
 #ifdef WE_HAVE_EC_KEY
 #ifdef WE_HAVE_EC_P256
@@ -185,6 +201,20 @@ TEST_CASE test_case[] = {
     #endif
     #ifdef WE_HAVE_ECDSA
         TEST_DECL(test_ec_key_ecdsa_p384, NULL),
+    #endif
+#endif
+#ifdef WE_HAVE_EC_P521
+    #ifdef WE_HAVE_ECKEYGEN
+        TEST_DECL(test_ec_key_keygen_p521_by_nid, NULL),
+    #endif
+    #ifdef WE_HAVE_ECDH
+    #ifdef WE_HAVE_ECKEYGEN
+        TEST_DECL(test_ec_key_ecdh_p521_keygen, NULL),
+    #endif
+        TEST_DECL(test_ec_key_ecdh_p521, NULL),
+    #endif
+    #ifdef WE_HAVE_ECDSA
+        TEST_DECL(test_ec_key_ecdsa_p521, NULL),
     #endif
 #endif
 #endif /* WE_HAVE_EC_KEY */

--- a/test/unit.h
+++ b/test/unit.h
@@ -176,6 +176,11 @@ int test_eckeygen_p384_by_nid(ENGINE *e, void *data);
 int test_eckeygen_p384(ENGINE *e, void *data);
 #endif /* WE_HAVE_EC_P384 */
 
+#ifdef WE_HAVE_EC_P521
+int test_eckeygen_p521_by_nid(ENGINE *e, void *data);
+int test_eckeygen_p521(ENGINE *e, void *data);
+#endif /* WE_HAVE_EC_P521 */
+
 #endif /* WE_HAVE_ECKEYGEN */
 
 #ifdef WE_HAVE_ECDH
@@ -192,6 +197,9 @@ int test_ecdh_p256_keygen(ENGINE *e, void *data);
 #ifdef WE_HAVE_EC_P384
 int test_ecdh_p384_keygen(ENGINE *e, void *data);
 #endif /* WE_HAVE_EC_P384 */
+#ifdef WE_HAVE_EC_P521
+int test_ecdh_p521_keygen(ENGINE *e, void *data);
+#endif /* WE_HAVE_EC_P521 */
 
 #endif /* WE_HAVE_ECKEYGEN */
 
@@ -204,6 +212,9 @@ int test_ecdh_p256(ENGINE *e, void *data);
 #ifdef WE_HAVE_EC_P384
 int test_ecdh_p384(ENGINE *e, void *data);
 #endif /* WE_HAVE_EC_P384 */
+#ifdef WE_HAVE_EC_P521
+int test_ecdh_p521(ENGINE *e, void *data);
+#endif /* WE_HAVE_EC_P521 */
 
 #endif /* WE_HAVE_ECDH */
 
@@ -217,6 +228,10 @@ int test_ecdsa_p256_pkey(ENGINE *e, void *data);
 int test_ecdsa_p384_pkey(ENGINE *e, void *data);
 #endif /* WE_HAVE_EC_P384 */
 
+#ifdef WE_HAVE_EC_P521
+int test_ecdsa_p521_pkey(ENGINE *e, void *data);
+#endif /* WE_HAVE_EC_P521 */
+
 #ifdef WE_HAVE_EC_P256
 int test_ecdsa_p256(ENGINE *e, void *data);
 #endif /* WE_HAVE_EC_P256 */
@@ -224,6 +239,10 @@ int test_ecdsa_p256(ENGINE *e, void *data);
 #ifdef WE_HAVE_EC_P384
 int test_ecdsa_p384(ENGINE *e, void *data);
 #endif /* WE_HAVE_EC_P384 */
+
+#ifdef WE_HAVE_EC_P521
+int test_ecdsa_p521(ENGINE *e, void *data);
+#endif /* WE_HAVE_EC_P521 */
 
 #endif /* WE_HAVE_ECDSA */
 
@@ -243,6 +262,10 @@ int test_ec_key_keygen_p256_by_nid(ENGINE *e, void *data);
 int test_ec_key_keygen_p384_by_nid(ENGINE *e, void *data);
 #endif /* WE_HAVE_EC_P384 */
 
+#ifdef WE_HAVE_EC_P521
+int test_ec_key_keygen_p521_by_nid(ENGINE *e, void *data);
+#endif /* WE_HAVE_EC_P521 */
+
 #endif /* WE_HAVE_ECKEYGEN */
 
 #ifdef WE_HAVE_ECDH
@@ -256,6 +279,9 @@ int test_ec_key_ecdh_p256_keygen(ENGINE *e, void *data);
 #ifdef WE_HAVE_EC_P384
 int test_ec_key_ecdh_p384_keygen(ENGINE *e, void *data);
 #endif /* WE_HAVE_EC_P384 */
+#ifdef WE_HAVE_EC_P521
+int test_ec_key_ecdh_p521_keygen(ENGINE *e, void *data);
+#endif /* WE_HAVE_EC_P521 */
 
 #endif /* WE_HAVE_ECKEYGEN */
 
@@ -268,6 +294,9 @@ int test_ec_key_ecdh_p256(ENGINE *e, void *data);
 #ifdef WE_HAVE_EC_P384
 int test_ec_key_ecdh_p384(ENGINE *e, void *data);
 #endif /* WE_HAVE_EC_P384 */
+#ifdef WE_HAVE_EC_P521
+int test_ec_key_ecdh_p521(ENGINE *e, void *data);
+#endif /* WE_HAVE_EC_P521 */
 
 #endif /* WE_HAVE_ECDH */
 
@@ -287,6 +316,9 @@ int test_ec_key_ecdsa_p256(ENGINE *e, void *data);
 #ifdef WE_HAVE_EC_P384
 int test_ec_key_ecdsa_p384(ENGINE *e, void *data);
 #endif /* WE_HAVE_EC_P384 */
+#ifdef WE_HAVE_EC_P521
+int test_ec_key_ecdsa_p521(ENGINE *e, void *data);
+#endif /* WE_HAVE_EC_P521 */
 
 #endif /* WE_HAVE_ECDSA */
 


### PR DESCRIPTION
This PR adds support to EVP_PKEY for ECC P-521 (secp521r1).  This mirrors existing support we already had existing for P-256 and P-384.