### PR TITLE
Add EVP_CIPH_FLAG_DEFAULT_ASN1 to cipher flags.

### DIFF
--- a/src/aes_block.c
+++ b/src/aes_block.c
@@ -462,6 +462,7 @@ static int we_aes_cbc_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
 #define AES_CBC_FLAGS              \
     (EVP_CIPH_FLAG_CUSTOM_CIPHER | \
      EVP_CIPH_ALWAYS_CALL_INIT   | \
+     EVP_CIPH_FLAG_DEFAULT_ASN1  | \
      EVP_CIPH_CBC_MODE)
 
 /** AES128-CBC EVP cipher method. */
@@ -987,6 +988,7 @@ static int we_aes_ecb_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
 #define AES_ECB_FLAGS              \
     (EVP_CIPH_FLAG_CUSTOM_CIPHER | \
      EVP_CIPH_ALWAYS_CALL_INIT   | \
+     EVP_CIPH_FLAG_DEFAULT_ASN1  | \
      EVP_CIPH_ECB_MODE)
 
 /** AES128-ECB EVP cipher method. */

--- a/src/aes_cbc_hmac.c
+++ b/src/aes_cbc_hmac.c
@@ -465,6 +465,7 @@ static int we_aes_cbc_hmac_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg,
     (EVP_CIPH_FLAG_CUSTOM_CIPHER        | \
      EVP_CIPH_ALWAYS_CALL_INIT          | \
      EVP_CIPH_CBC_MODE                  | \
+     EVP_CIPH_FLAG_DEFAULT_ASN1         | \
      EVP_CIPH_FLAG_AEAD_CIPHER)
 
 /** AES128-CBC HMAC SHA256 EVP cipher method. */

--- a/src/aes_ccm.c
+++ b/src/aes_ccm.c
@@ -523,6 +523,7 @@ static int we_aes_ccm_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
      EVP_CIPH_CUSTOM_IV_LENGTH   | \
      EVP_CIPH_ALWAYS_CALL_INIT   | \
      EVP_CIPH_FLAG_AEAD_CIPHER   | \
+     EVP_CIPH_FLAG_DEFAULT_ASN1  | \
      EVP_CIPH_CCM_MODE)
 
 /** AES128-CCM EVP cipher method. */

--- a/src/aes_ctr.c
+++ b/src/aes_ctr.c
@@ -188,6 +188,7 @@ static int we_aes_ctr_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
 #define AES_CTR_FLAGS              \
     (EVP_CIPH_FLAG_CUSTOM_CIPHER | \
      EVP_CIPH_ALWAYS_CALL_INIT   | \
+     EVP_CIPH_FLAG_DEFAULT_ASN1  | \
      EVP_CIPH_CTR_MODE)
 
 /** AES128-CTR EVP cipher method. */

--- a/src/aes_gcm.c
+++ b/src/aes_gcm.c
@@ -543,6 +543,7 @@ static int we_aes_gcm_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
      EVP_CIPH_ALWAYS_CALL_INIT   | \
      EVP_CIPH_CTRL_INIT          | \
      EVP_CIPH_FLAG_AEAD_CIPHER   | \
+     EVP_CIPH_FLAG_DEFAULT_ASN1  | \
      EVP_CIPH_GCM_MODE)
 
 /** AES128-GCM EVP cipher method. */

--- a/src/des3_cbc.c
+++ b/src/des3_cbc.c
@@ -458,6 +458,7 @@ static int we_des3_cbc_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
 #define DES3_CBC_FLAGS             \
     (EVP_CIPH_FLAG_CUSTOM_CIPHER | \
      EVP_CIPH_ALWAYS_CALL_INIT   | \
+     EVP_CIPH_FLAG_DEFAULT_ASN1  | \
      EVP_CIPH_CBC_MODE)
 
 /** DES3-CBC EVP cipher method. */


### PR DESCRIPTION
Customer needed to add this to get AES-GCM working, apparently. Since we don't implement the `set_asn1_parameters` and `get_asn1_parameters` functions for our cipher implementations, it makes since to add this flag.