### PR TITLE
fix clang scan-build issues

### DIFF
--- a/src/aes_block.c
+++ b/src/aes_block.c
@@ -202,7 +202,6 @@ static int we_aes_cbc_encrypt(EVP_CIPHER_CTX *ctx, we_AesBlock* aes,
                 ret = 0;
             }
 
-            out += l;
             outl += l;
             in += l;
             len -= l;
@@ -351,7 +350,6 @@ static int we_aes_cbc_decrypt(EVP_CIPHER_CTX *ctx, we_AesBlock* aes,
                 }
             }
 
-            out += l;
             outl += l;
             in += l;
             len -= l;
@@ -728,7 +726,6 @@ static int we_aes_ecb_encrypt(EVP_CIPHER_CTX *ctx, we_AesBlock* aes,
                 ret = 0;
             }
 
-            out += l;
             outl += l;
             in += l;
             len -= l;
@@ -877,7 +874,6 @@ static int we_aes_ecb_decrypt(EVP_CIPHER_CTX *ctx, we_AesBlock* aes,
                 }
             }
 
-            out += l;
             outl += l;
             in += l;
             len -= l;

--- a/src/aes_cbc_hmac.c
+++ b/src/aes_cbc_hmac.c
@@ -231,10 +231,7 @@ static int we_aes_cbc_hmac_dec(we_AesCbcHmac* aes, unsigned char *out,
     /* Get payload length. */
     pLen = aes->pLen;
     tls = (pLen != 0);
-    if (!tls) {
-        pLen = (int)len;
-    }
-    else if (aes->tls11) {
+    if (aes->tls11) {
         /* TLS v1.1 and v1.2 have IV before message. */
         off = AES_BLOCK_SIZE;
         rc = wc_AesSetIV(&aes->aes, in);

--- a/src/des3_cbc.c
+++ b/src/des3_cbc.c
@@ -198,7 +198,6 @@ static int we_des3_cbc_encrypt(EVP_CIPHER_CTX *ctx, we_Des3Cbc* des3,
                 ret = 0;
             }
 
-            out += l;
             outl += l;
             in += l;
             len -= l;
@@ -347,7 +346,6 @@ static int we_des3_cbc_decrypt(EVP_CIPHER_CTX *ctx, we_Des3Cbc* des3,
                 }
             }
 
-            out += l;
             outl += l;
             in += l;
             len -= l;

--- a/src/dh.c
+++ b/src/dh.c
@@ -368,6 +368,7 @@ static int we_dh_compute_key(unsigned char *key, const BIGNUM *pubKey, DH *dh)
         OPENSSL_free(privBuf);
 
     WOLFENGINE_LEAVE("we_compute_key", ret);
+    (void)ret;
 
     return keyLen;
 }

--- a/test/test_cmac.c
+++ b/test/test_cmac.c
@@ -146,10 +146,12 @@ int test_cmac_create(ENGINE *e, void *data)
     ret = test_cmac_create_helper(e, in, inSz, key, keySz,
             EVP_aes_256_cbc());
 
-    PRINT_MSG("Testing with 128 bit KEY");
-    keySz = 16;
-    ret = test_cmac_create_helper(e, in, inSz, key, keySz,
-            EVP_aes_128_cbc());
+    if (ret == 0) {
+        PRINT_MSG("Testing with 128 bit KEY");
+        keySz = 16;
+        ret = test_cmac_create_helper(e, in, inSz, key, keySz,
+                EVP_aes_128_cbc());
+    }
 
     return ret;
 }

--- a/test/test_ecc.c
+++ b/test/test_ecc.c
@@ -698,7 +698,7 @@ int test_ecdh(ENGINE *e, const unsigned char *privKey, size_t len,
               const unsigned char *peerPrivKey, size_t peerLen,
               const unsigned char *derived, size_t dLen)
 {
-    int err;
+    int err = 0;
     EVP_PKEY_CTX *kgCtx = NULL;
     EVP_PKEY *keyA = NULL;
     EVP_PKEY *keyB = NULL;
@@ -707,8 +707,10 @@ int test_ecdh(ENGINE *e, const unsigned char *privKey, size_t len,
     const unsigned char *p;
 
     p = privKey;
-    err = (keyA = d2i_PrivateKey(EVP_PKEY_EC, NULL, &p, len)) == NULL;
-    err = keyA == NULL;
+    keyA = d2i_PrivateKey(EVP_PKEY_EC, NULL, &p, len);
+    if (keyA == NULL) {
+        err = 1;
+    }
     if (err == 0) {
         p = peerPrivKey;
         err = (keyB = d2i_PrivateKey(EVP_PKEY_EC, NULL, &p, peerLen)) == NULL;


### PR DESCRIPTION
This PR fixes clang scan build issues.  Tested using clang 10.0.0-4ubuntu1, with both OpenSSL 1.0.2h and 1.1.1b.