### PR TITLE
add log level support and logging by component

### DIFF
--- a/include/we_logging.h
+++ b/include/we_logging.h
@@ -26,6 +26,20 @@
 #define WOLFENGINE_MAX_ERROR_SZ 80
 #endif
 
+/* wolfEngine debug logging support can be compiled in by defining
+ * WOLFENGINE_DEBUG or by using the --enable-debug configure option.
+ *
+ * wolfEngine supports the log levels as mentioned in wolfEngine_LogType
+ * enum below. The default logging level when debug logging is compiled in
+ * and enabled at runtime is WE_LOG_LEVEL_DEFAULT.
+ *
+ * wolfEngine supports log message control per-component/algorithm type,
+ * with all possible logging components in wolfEngine_LogComponents enum
+ * below. The default logging level when debug logging is compiled in and
+ * enabled at runtime is WE_LOG_COMPONENTS_DEFAULT.
+ *
+ */
+
 /* Possible debug/logging options:
  *
  * WOLFENGINE_DEBUG       Define to enable debug logging (or --enable-debug)
@@ -38,16 +52,51 @@
  *                        for logs. Not applicable if using WOLFENGINE_USER_LOG
  *                        or custom logging callback.
  */
-
 enum wolfEngine_LogType {
-    WE_LOG_ERROR = 0,
-    WE_LOG_ENTER,
-    WE_LOG_LEAVE,
-    WE_LOG_INFO,
-    WE_LOG_VERBOSE
+    WE_LOG_ERROR   = 0x0001,  /* logs errors */
+    WE_LOG_ENTER   = 0x0002,  /* logs function enter*/
+    WE_LOG_LEAVE   = 0x0004,  /* logs function leave */
+    WE_LOG_INFO    = 0x0008,  /* logs informative messages */
+    WE_LOG_VERBOSE = 0x0010,  /* logs encrypted/decrypted/digested data */
+
+    /* default log level when logging is turned on, all but verbose */
+    WE_LOG_LEVEL_DEFAULT = (WE_LOG_ERROR
+                          | WE_LOG_ENTER
+                          | WE_LOG_LEAVE
+                          | WE_LOG_INFO),
+
+    /* log all, including verbose */
+    WE_LOG_LEVEL_ALL = (WE_LOG_ERROR
+                      | WE_LOG_ENTER
+                      | WE_LOG_LEAVE
+                      | WE_LOG_INFO
+                      | WE_LOG_VERBOSE)
+};
+
+enum wolfEngine_LogComponents {
+    WE_LOG_RNG    = 0x0001,  /* random number generation */
+    WE_LOG_DIGEST = 0x0002,  /* digest (SHA-1/2/3) */
+    WE_LOG_MAC    = 0x0004,  /* mac functions: HMAC, CMAC */
+    WE_LOG_CIPHER = 0x0008,  /* cipher (AES, 3DES) */
+    WE_LOG_PK     = 0x0010,  /* public key algorithms (RSA, ECC) */
+    WE_LOG_KE     = 0x0020,  /* key agreement (DH, ECDH) */
+    WE_LOG_ENGINE = 0x0040,  /* all engine specific logs */
+
+    /* log all compoenents */
+    WE_LOG_COMPONENTS_ALL = (WE_LOG_RNG
+                           | WE_LOG_DIGEST
+                           | WE_LOG_MAC
+                           | WE_LOG_CIPHER
+                           | WE_LOG_PK
+                           | WE_LOG_KE
+                           | WE_LOG_ENGINE),
+
+    /* default compoenents logged */
+    WE_LOG_COMPONENTS_DEFAULT = WE_LOG_COMPONENTS_ALL
 };
 
 typedef void (*wolfEngine_Logging_cb)(const int logLevel,
+                                      const int component,
                                       const char *const logMessage);
 int wolfEngine_SetLoggingCb(wolfEngine_Logging_cb logF);
 
@@ -56,38 +105,45 @@ int  wolfEngine_Debugging_ON(void);
 /* turn logging off */
 void wolfEngine_Debugging_OFF(void);
 
+/* Set logging level, bitmask of wolfEngine_LogType */
+int wolfEngine_SetLogLevel(int levelMask);
+/* Set which components are logged, bitmask of wolfEngine_LogComponents */
+int wolfEngine_SetLogComponents(int componentMask);
+
 #ifdef WOLFENGINE_DEBUG
 
-#define WOLFENGINE_ERROR(err)                                           \
-    WOLFENGINE_ERROR_LINE(err, __FILE__, __LINE__)
-#define WOLFENGINE_ERROR_MSG(msg)                                       \
-    WOLFENGINE_ERROR_MSG_LINE(msg, __FILE__, __LINE__)
-#define WOLFENGINE_ERROR_FUNC(funcName, ret)                            \
-    WOLFENGINE_ERROR_FUNC_LINE(funcName, ret, __FILE__, __LINE__)
-#define WOLFENGINE_ERROR_FUNC_NULL(funcName, ret)                       \
-    WOLFENGINE_ERROR_FUNC_NULL_LINE(funcName, ret, __FILE__, __LINE__)
+#define WOLFENGINE_ERROR(type, err)                                     \
+    WOLFENGINE_ERROR_LINE(type, err, __FILE__, __LINE__)
+#define WOLFENGINE_ERROR_MSG(type, msg)                                 \
+    WOLFENGINE_ERROR_MSG_LINE(type, msg, __FILE__, __LINE__)
+#define WOLFENGINE_ERROR_FUNC(type, funcName, ret)                      \
+    WOLFENGINE_ERROR_FUNC_LINE(type, funcName, ret, __FILE__, __LINE__)
+#define WOLFENGINE_ERROR_FUNC_NULL(type, funcName, ret)                  \
+    WOLFENGINE_ERROR_FUNC_NULL_LINE(type, funcName, ret, __FILE__, __LINE__)
 
-void WOLFENGINE_ENTER(const char* msg);
-void WOLFENGINE_LEAVE(const char* msg, int ret);
-void WOLFENGINE_MSG(const char* msg);
-void WOLFENGINE_ERROR_LINE(int err, const char* file, int line);
-void WOLFENGINE_ERROR_MSG_LINE(const char* msg, const char* file, int line);
-void WOLFENGINE_ERROR_FUNC_LINE(const char* funcName, int ret, const char* file,
-                                int line);
-void WOLFENGINE_ERROR_FUNC_NULL_LINE(const char* funcName, void *ret,
+void WOLFENGINE_ENTER(int type, const char* msg);
+void WOLFENGINE_LEAVE(int type, const char* msg, int ret);
+void WOLFENGINE_MSG(int type, const char* msg);
+void WOLFENGINE_ERROR_LINE(int type, int err, const char* file, int line);
+void WOLFENGINE_ERROR_MSG_LINE(int type, const char* msg, const char* file,
+                               int line);
+void WOLFENGINE_ERROR_FUNC_LINE(int type, const char* funcName, int ret,
+                                const char* file, int line);
+void WOLFENGINE_ERROR_FUNC_NULL_LINE(int type, const char* funcName, void *ret,
                                      const char* file, int line);
-void WOLFENGINE_BUFFER(const unsigned char* buffer, unsigned int length);
+void WOLFENGINE_BUFFER(int type, const unsigned char* buffer,
+                       unsigned int length);
 
 #else
 
-#define WOLFENGINE_ENTER(m)
-#define WOLFENGINE_LEAVE(m, r)
-#define WOLFENGINE_MSG(m)
-#define WOLFENGINE_ERROR(e)
-#define WOLFENGINE_ERROR_MSG(e)
-#define WOLFENGINE_ERROR_FUNC(f, r)
-#define WOLFENGINE_ERROR_FUNC_NULL(f, r)
-#define WOLFENGINE_BUFFER(b, l)
+#define WOLFENGINE_ENTER(t, m)
+#define WOLFENGINE_LEAVE(t, m, r)
+#define WOLFENGINE_MSG(t, m)
+#define WOLFENGINE_ERROR(t, e)
+#define WOLFENGINE_ERROR_MSG(t, e)
+#define WOLFENGINE_ERROR_FUNC(t, f, r)
+#define WOLFENGINE_ERROR_FUNC_NULL(t, f, r)
+#define WOLFENGINE_BUFFER(t, b, l)
 
 #endif /* WOLFENGINE_DEBUG */
 

--- a/src/aes_block.c
+++ b/src/aes_block.c
@@ -65,7 +65,7 @@ static int we_aes_cbc_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
     int rc;
     we_AesBlock *aes;
 
-    WOLFENGINE_ENTER("we_aes_cbc_init");
+    WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_aes_cbc_init");
 
     if ((iv == NULL) && (key == NULL)) {
         ret = 0;
@@ -74,7 +74,8 @@ static int we_aes_cbc_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
     if (ret == 1) {
         aes = (we_AesBlock *)EVP_CIPHER_CTX_get_cipher_data(ctx);
         if (aes == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("EVP_CIPHER_CTX_get_cipher_data", aes);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER,
+                                       "EVP_CIPHER_CTX_get_cipher_data", aes);
             ret = 0;
         }
     }
@@ -82,7 +83,7 @@ static int we_aes_cbc_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
     if ((ret == 1) && (!aes->init)) {
         rc = wc_AesInit(&aes->aes, NULL, INVALID_DEVID);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_AesInit", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER, "wc_AesInit", rc);
             ret = 0;
         }
     }
@@ -98,20 +99,20 @@ static int we_aes_cbc_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
             rc = wc_AesSetKey(&aes->aes, key, EVP_CIPHER_CTX_key_length(ctx),
                               iv, enc ? AES_ENCRYPTION : AES_DECRYPTION);
             if (rc != 0) {
-                WOLFENGINE_ERROR_FUNC("wc_AesSetKey", rc);
+                WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER, "wc_AesSetKey", rc);
                 ret = 0;
             }
         }
         else {
             rc = wc_AesSetIV(&aes->aes, iv);
             if (rc != 0) {
-                WOLFENGINE_ERROR_FUNC("wc_AesSetIV", rc);
+                WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER, "wc_AesSetIV", rc);
                 ret = 0;
             }
         }
     }
 
-    WOLFENGINE_LEAVE("we_aes_cbc_init", ret);
+    WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_aes_cbc_init", ret);
 
     return ret;
 }
@@ -137,13 +138,14 @@ static int we_aes_cbc_encrypt(EVP_CIPHER_CTX *ctx, we_AesBlock* aes,
     int outl = 0;
     int noPad = EVP_CIPHER_CTX_test_flags(ctx, EVP_CIPH_NO_PADDING);
 
-    WOLFENGINE_ENTER("we_aes_cbc_encrypt");
+    WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_aes_cbc_encrypt");
 
     /* Length of 0 means Final called. */
     if (len == 0) {
         if (noPad) {
             if (aes->over != 0) {
-                WOLFENGINE_ERROR_MSG("No Pad - last encrypt block not full");
+                WOLFENGINE_ERROR_MSG(WE_LOG_CIPHER,
+                                     "No Pad - last encrypt block not full");
                 ret = 0;
             }
         }
@@ -181,7 +183,8 @@ static int we_aes_cbc_encrypt(EVP_CIPHER_CTX *ctx, we_AesBlock* aes,
                 rc = wc_AesCbcEncrypt(&aes->aes, out, aes->lastBlock,
                                       AES_BLOCK_SIZE);
                 if (rc != 0) {
-                    WOLFENGINE_ERROR_FUNC("wc_AesCbcEncrypt", rc);
+                    WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER,
+                                          "wc_AesCbcEncrypt", rc);
                     ret = 0;
                 }
                 /* Data put to output. */
@@ -198,7 +201,7 @@ static int we_aes_cbc_encrypt(EVP_CIPHER_CTX *ctx, we_AesBlock* aes,
 
             rc = wc_AesCbcEncrypt(&aes->aes, out, in, l);
             if (rc != 0) {
-                WOLFENGINE_ERROR_FUNC("wc_AesCbcEncrypt", rc);
+                WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER, "wc_AesCbcEncrypt", rc);
                 ret = 0;
             }
 
@@ -221,7 +224,7 @@ static int we_aes_cbc_encrypt(EVP_CIPHER_CTX *ctx, we_AesBlock* aes,
         ret = -1;
     }
 
-    WOLFENGINE_LEAVE("we_aes_cbc_encrypt", ret);
+    WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_aes_cbc_encrypt", ret);
 
     return ret;
 }
@@ -247,13 +250,14 @@ static int we_aes_cbc_decrypt(EVP_CIPHER_CTX *ctx, we_AesBlock* aes,
     int outl = 0;
     int noPad = EVP_CIPHER_CTX_test_flags(ctx, EVP_CIPH_NO_PADDING);
 
-    WOLFENGINE_ENTER("we_aes_cbc_decrypt");
+    WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_aes_cbc_decrypt");
 
     /* Length of 0 means Final called. */
     if (len == 0) {
         if (noPad) {
             if (aes->over != 0) {
-                WOLFENGINE_ERROR_MSG("No Pad - last decrypt block not full");
+                WOLFENGINE_ERROR_MSG(WE_LOG_CIPHER,
+                                     "No Pad - last decrypt block not full");
                 ret = 0;
             }
         }
@@ -263,7 +267,8 @@ static int we_aes_cbc_decrypt(EVP_CIPHER_CTX *ctx, we_AesBlock* aes,
 
             /* Must have a full block over to decrypt. */
             if (aes->over != AES_BLOCK_SIZE) {
-                WOLFENGINE_ERROR_MSG("Padding - last cached decrypt block not "
+                WOLFENGINE_ERROR_MSG(WE_LOG_CIPHER,
+                                     "Padding - last cached decrypt block not "
                                      "full");
                 ret = 0;
             }
@@ -272,7 +277,8 @@ static int we_aes_cbc_decrypt(EVP_CIPHER_CTX *ctx, we_AesBlock* aes,
                 rc = wc_AesCbcDecrypt(&aes->aes, aes->lastBlock, aes->lastBlock,
                                       AES_BLOCK_SIZE);
                 if (rc != 0) {
-                    WOLFENGINE_ERROR_FUNC("wc_AesCbcDecrypt", rc);
+                    WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER,
+                                          "wc_AesCbcDecrypt", rc);
                     ret = 0;
                 }
                 aes->over = 0;
@@ -281,7 +287,7 @@ static int we_aes_cbc_decrypt(EVP_CIPHER_CTX *ctx, we_AesBlock* aes,
                 /* Last byte is length of padding. */
                 pad = aes->lastBlock[AES_BLOCK_SIZE - 1];
                 if ((pad == 0) || (pad > AES_BLOCK_SIZE)) {
-                    WOLFENGINE_ERROR_MSG("Padding byte invalid");
+                    WOLFENGINE_ERROR_MSG(WE_LOG_CIPHER, "Padding byte invalid");
                     ret = 0;
                 }
             }
@@ -292,7 +298,8 @@ static int we_aes_cbc_decrypt(EVP_CIPHER_CTX *ctx, we_AesBlock* aes,
                 /* Check padding bytes are all the same. */
                 for (i = outl; (ret == 1) && (i < AES_BLOCK_SIZE - 1); i++) {
                    if (aes->lastBlock[i] != pad) {
-                       WOLFENGINE_ERROR_MSG("Padding byte doesn't different");
+                       WOLFENGINE_ERROR_MSG(WE_LOG_CIPHER,
+                                            "Padding byte doesn't different");
                        ret = 0;
                    }
                 }
@@ -323,7 +330,8 @@ static int we_aes_cbc_decrypt(EVP_CIPHER_CTX *ctx, we_AesBlock* aes,
                 rc = wc_AesCbcDecrypt(&aes->aes, out, aes->lastBlock,
                                       AES_BLOCK_SIZE);
                 if (rc != 0) {
-                    WOLFENGINE_ERROR_FUNC("wc_AesCbcDecrypt", rc);
+                    WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER,
+                                          "wc_AesCbcDecrypt", rc);
                     ret = 0;
                 }
                 /* Data put to output. */
@@ -345,7 +353,8 @@ static int we_aes_cbc_decrypt(EVP_CIPHER_CTX *ctx, we_AesBlock* aes,
             if (l > 0) {
                 rc = wc_AesCbcDecrypt(&aes->aes, out, in, l);
                 if (rc != 0) {
-                    WOLFENGINE_ERROR_FUNC("wc_AesCbcDecrypt", rc);
+                    WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER,
+                                          "wc_AesCbcDecrypt", rc);
                     ret = 0;
                 }
             }
@@ -369,7 +378,7 @@ static int we_aes_cbc_decrypt(EVP_CIPHER_CTX *ctx, we_AesBlock* aes,
         ret = -1;
     }
 
-    WOLFENGINE_LEAVE("we_aes_cbc_decrypt", ret);
+    WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_aes_cbc_decrypt", ret);
 
     return ret;
 }
@@ -392,12 +401,13 @@ static int we_aes_cbc_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
     int ret;
     we_AesBlock* aes;
 
-    WOLFENGINE_ENTER("we_aes_cbc_cipher");
+    WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_aes_cbc_cipher");
 
     /* Get the AES-CBC object to work with. */
     aes = (we_AesBlock *)EVP_CIPHER_CTX_get_cipher_data(ctx);
     if (aes == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("EVP_CIPHER_CTX_get_cipher_data", aes);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER,
+                                   "EVP_CIPHER_CTX_get_cipher_data", aes);
         ret = -1;
     }
     else if (aes->enc) {
@@ -407,7 +417,7 @@ static int we_aes_cbc_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
         ret = we_aes_cbc_decrypt(ctx, aes, out, in, len);
     }
 
-    WOLFENGINE_LEAVE("we_aes_cbc_cipher", ret);
+    WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_aes_cbc_cipher", ret);
 
     return ret;
 }
@@ -429,7 +439,7 @@ static int we_aes_cbc_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
     we_AesBlock *aes;
     char errBuff[WOLFENGINE_MAX_ERROR_SZ];
 
-    WOLFENGINE_ENTER("we_aes_cbc_ctrl");
+    WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_aes_cbc_ctrl");
 
     (void)arg;
     (void)ptr;
@@ -437,7 +447,8 @@ static int we_aes_cbc_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
     /* Get the AES-CBC data to work with. */
     aes = (we_AesBlock *)EVP_CIPHER_CTX_get_cipher_data(ctx);
     if (aes != NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("EVP_CIPHER_CTX_get_cipher_data", aes);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER,
+                                   "EVP_CIPHER_CTX_get_cipher_data", aes);
         ret = 0;
     }
     if (ret == 1) {
@@ -445,13 +456,13 @@ static int we_aes_cbc_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
             default:
                 XSNPRINTF(errBuff, sizeof(errBuff), "Unsupported ctrl type %d",
                           type);
-                WOLFENGINE_ERROR_MSG(errBuff);
+                WOLFENGINE_ERROR_MSG(WE_LOG_CIPHER, errBuff);
                 ret = 0;
                 break;
         }
     }
 
-    WOLFENGINE_LEAVE("we_aes_cbc_ctrl", ret);
+    WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_aes_cbc_ctrl", ret);
 
     return ret;
 }
@@ -480,7 +491,7 @@ static int we_init_aescbc_meth(EVP_CIPHER *cipher)
 {
     int ret;
 
-    WOLFENGINE_ENTER("we_init_aescbc_meth");
+    WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_init_aescbc_meth");
 
     ret = EVP_CIPHER_meth_set_iv_length(cipher, AES_IV_SIZE);
     if (ret == 1) {
@@ -499,7 +510,7 @@ static int we_init_aescbc_meth(EVP_CIPHER *cipher)
         ret = EVP_CIPHER_meth_set_impl_ctx_size(cipher, sizeof(we_AesBlock));
     }
 
-    WOLFENGINE_LEAVE("we_init_aescbc_meth", ret);
+    WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_init_aescbc_meth", ret);
 
     return ret;
 }
@@ -513,13 +524,14 @@ int we_init_aescbc_meths()
 {
     int ret = 1;
 
-    WOLFENGINE_ENTER("we_init_aescbc_meths");
+    WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_init_aescbc_meths");
 
     /* AES128-CBC */
     we_aes128_cbc_ciph = EVP_CIPHER_meth_new(NID_aes_128_cbc, AES_BLOCK_SIZE,
                                              AES_128_KEY_SIZE);
     if (we_aes128_cbc_ciph == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("EVP_CIPHER_meth_new - AES-128-CBC",
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER,
+                                   "EVP_CIPHER_meth_new - AES-128-CBC",
                                    we_aes128_cbc_ciph);
         ret = 0;
     }
@@ -533,7 +545,8 @@ int we_init_aescbc_meths()
                                                  AES_BLOCK_SIZE,
                                                  AES_192_KEY_SIZE);
         if (we_aes192_cbc_ciph == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("EVP_CIPHER_meth_new - AES-192-CBC",
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER,
+                                       "EVP_CIPHER_meth_new - AES-192-CBC",
                                        we_aes192_cbc_ciph);
             ret = 0;
         }
@@ -548,7 +561,8 @@ int we_init_aescbc_meths()
                                                  AES_BLOCK_SIZE,
                                                  AES_256_KEY_SIZE);
         if (we_aes256_cbc_ciph == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("EVP_CIPHER_meth_new - AES-256-CBC",
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER,
+                                       "EVP_CIPHER_meth_new - AES-256-CBC",
                                        we_aes256_cbc_ciph);
             ret = 0;
         }
@@ -571,7 +585,7 @@ int we_init_aescbc_meths()
         we_aes256_cbc_ciph = NULL;
     }
 
-    WOLFENGINE_LEAVE("we_init_aescbc_meths", ret);
+    WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_init_aescbc_meths", ret);
 
     return ret;
 }
@@ -600,20 +614,21 @@ static int we_aes_ecb_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
     int rc;
     we_AesBlock *aes;
 
-    WOLFENGINE_ENTER("we_aes_ecb_init");
+    WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_aes_ecb_init");
 
     (void)iv;
 
     aes = (we_AesBlock *)EVP_CIPHER_CTX_get_cipher_data(ctx);
     if (aes == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("EVP_CIPHER_CTX_get_cipher_data", aes);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER,
+                                   "EVP_CIPHER_CTX_get_cipher_data", aes);
         ret = 0;
     }
 
     if ((ret == 1) && ((key == NULL) || (!aes->init))) {
         rc = wc_AesInit(&aes->aes, NULL, INVALID_DEVID);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_AesInit", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER, "wc_AesInit", rc);
             ret = 0;
         }
     }
@@ -630,12 +645,12 @@ static int we_aes_ecb_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
         rc = wc_AesSetKey(&aes->aes, key, EVP_CIPHER_CTX_key_length(ctx),
                           NULL, enc ? AES_ENCRYPTION : AES_DECRYPTION);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_AesSetKey", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER, "wc_AesSetKey", rc);
             ret = 0;
         }
     }
 
-    WOLFENGINE_LEAVE("we_aes_ecb_init", ret);
+    WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_aes_ecb_init", ret);
 
     return ret;
 }
@@ -661,13 +676,14 @@ static int we_aes_ecb_encrypt(EVP_CIPHER_CTX *ctx, we_AesBlock* aes,
     int outl = 0;
     int noPad = EVP_CIPHER_CTX_test_flags(ctx, EVP_CIPH_NO_PADDING);
 
-    WOLFENGINE_ENTER("we_aes_ecb_encrypt");
+    WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_aes_ecb_encrypt");
 
     /* Length of 0 means Final called. */
     if (len == 0) {
         if (noPad) {
             if (aes->over != 0) {
-                WOLFENGINE_ERROR_MSG("No Pad - last encrypt block not full");
+                WOLFENGINE_ERROR_MSG(WE_LOG_CIPHER,
+                                     "No Pad - last encrypt block not full");
                 ret = 0;
             }
         }
@@ -705,7 +721,8 @@ static int we_aes_ecb_encrypt(EVP_CIPHER_CTX *ctx, we_AesBlock* aes,
                 rc = wc_AesEcbEncrypt(&aes->aes, out, aes->lastBlock,
                                       AES_BLOCK_SIZE);
                 if (rc != 0) {
-                    WOLFENGINE_ERROR_FUNC("wc_AesEcbEncrypt", rc);
+                    WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER,
+                                          "wc_AesEcbEncrypt", rc);
                     ret = 0;
                 }
                 /* Data put to output. */
@@ -722,7 +739,7 @@ static int we_aes_ecb_encrypt(EVP_CIPHER_CTX *ctx, we_AesBlock* aes,
 
             rc = wc_AesEcbEncrypt(&aes->aes, out, in, l);
             if (rc != 0) {
-                WOLFENGINE_ERROR_FUNC("wc_AesEcbEncrypt", rc);
+                WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER, "wc_AesEcbEncrypt", rc);
                 ret = 0;
             }
 
@@ -745,7 +762,7 @@ static int we_aes_ecb_encrypt(EVP_CIPHER_CTX *ctx, we_AesBlock* aes,
         ret = -1;
     }
 
-    WOLFENGINE_LEAVE("we_aes_ecb_encrypt", ret);
+    WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_aes_ecb_encrypt", ret);
 
     return ret;
 }
@@ -771,13 +788,14 @@ static int we_aes_ecb_decrypt(EVP_CIPHER_CTX *ctx, we_AesBlock* aes,
     int outl = 0;
     int noPad = EVP_CIPHER_CTX_test_flags(ctx, EVP_CIPH_NO_PADDING);
 
-    WOLFENGINE_ENTER("we_aes_ecb_decrypt");
+    WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_aes_ecb_decrypt");
 
     /* Length of 0 means Final called. */
     if (len == 0) {
         if (noPad) {
             if (aes->over != 0) {
-                WOLFENGINE_ERROR_MSG("No Pad - last decrypt block not full");
+                WOLFENGINE_ERROR_MSG(WE_LOG_CIPHER,
+                                     "No Pad - last decrypt block not full");
                 ret = 0;
             }
         }
@@ -787,7 +805,8 @@ static int we_aes_ecb_decrypt(EVP_CIPHER_CTX *ctx, we_AesBlock* aes,
 
             /* Must have a full block over to decrypt. */
             if (aes->over != AES_BLOCK_SIZE) {
-                WOLFENGINE_ERROR_MSG("Padding - last cached decrypt block not "
+                WOLFENGINE_ERROR_MSG(WE_LOG_CIPHER,
+                                     "Padding - last cached decrypt block not "
                                      "full");
                 ret = 0;
             }
@@ -796,7 +815,8 @@ static int we_aes_ecb_decrypt(EVP_CIPHER_CTX *ctx, we_AesBlock* aes,
                 rc = wc_AesEcbDecrypt(&aes->aes, aes->lastBlock, aes->lastBlock,
                                       AES_BLOCK_SIZE);
                 if (rc != 0) {
-                    WOLFENGINE_ERROR_FUNC("wc_AesEcbDecrypt", rc);
+                    WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER,
+                                          "wc_AesEcbDecrypt", rc);
                     ret = 0;
                 }
                 aes->over = 0;
@@ -805,7 +825,7 @@ static int we_aes_ecb_decrypt(EVP_CIPHER_CTX *ctx, we_AesBlock* aes,
                 /* Last byte is length of padding. */
                 pad = aes->lastBlock[AES_BLOCK_SIZE - 1];
                 if ((pad == 0) || (pad > AES_BLOCK_SIZE)) {
-                    WOLFENGINE_ERROR_MSG("Padding byte invalid");
+                    WOLFENGINE_ERROR_MSG(WE_LOG_CIPHER, "Padding byte invalid");
                     ret = 0;
                 }
             }
@@ -816,7 +836,8 @@ static int we_aes_ecb_decrypt(EVP_CIPHER_CTX *ctx, we_AesBlock* aes,
                 /* Check padding bytes are all the same. */
                 for (i = outl; (ret == 1) && (i < AES_BLOCK_SIZE - 1); i++) {
                    if (aes->lastBlock[i] != pad) {
-                       WOLFENGINE_ERROR_MSG("Padding byte doesn't different");
+                       WOLFENGINE_ERROR_MSG(WE_LOG_CIPHER,
+                                            "Padding byte doesn't different");
                        ret = 0;
                    }
                 }
@@ -847,7 +868,8 @@ static int we_aes_ecb_decrypt(EVP_CIPHER_CTX *ctx, we_AesBlock* aes,
                 rc = wc_AesEcbDecrypt(&aes->aes, out, aes->lastBlock,
                                       AES_BLOCK_SIZE);
                 if (rc != 0) {
-                    WOLFENGINE_ERROR_FUNC("wc_AesEcbDecrypt", rc);
+                    WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER,
+                                          "wc_AesEcbDecrypt", rc);
                     ret = 0;
                 }
                 /* Data put to output. */
@@ -869,7 +891,8 @@ static int we_aes_ecb_decrypt(EVP_CIPHER_CTX *ctx, we_AesBlock* aes,
             if (l > 0) {
                 rc = wc_AesEcbDecrypt(&aes->aes, out, in, l);
                 if (rc != 0) {
-                    WOLFENGINE_ERROR_FUNC("wc_AesEcbDecrypt", rc);
+                    WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER,
+                                          "wc_AesEcbDecrypt", rc);
                     ret = 0;
                 }
             }
@@ -893,7 +916,7 @@ static int we_aes_ecb_decrypt(EVP_CIPHER_CTX *ctx, we_AesBlock* aes,
         ret = -1;
     }
 
-    WOLFENGINE_LEAVE("we_aes_ecb_decrypt", ret);
+    WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_aes_ecb_decrypt", ret);
 
     return ret;
 }
@@ -916,12 +939,13 @@ static int we_aes_ecb_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
     int ret;
     we_AesBlock* aes;
 
-    WOLFENGINE_ENTER("we_aes_ecb_cipher");
+    WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_aes_ecb_cipher");
 
     /* Get the AES object to work with. */
     aes = (we_AesBlock *)EVP_CIPHER_CTX_get_cipher_data(ctx);
     if (aes == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("EVP_CIPHER_CTX_get_cipher_data", aes);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER,
+                                   "EVP_CIPHER_CTX_get_cipher_data", aes);
         ret = -1;
     }
     else if (aes->enc) {
@@ -931,7 +955,7 @@ static int we_aes_ecb_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
         ret = we_aes_ecb_decrypt(ctx, aes, out, in, len);
     }
 
-    WOLFENGINE_LEAVE("we_aes_ecb_cipher", ret);
+    WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_aes_ecb_cipher", ret);
 
     return ret;
 }
@@ -953,7 +977,7 @@ static int we_aes_ecb_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
     we_AesBlock *aes;
     char errBuff[WOLFENGINE_MAX_ERROR_SZ];
 
-    WOLFENGINE_ENTER("we_aes_ecb_ctrl");
+    WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_aes_ecb_ctrl");
 
     (void)arg;
     (void)ptr;
@@ -961,7 +985,8 @@ static int we_aes_ecb_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
     /* Get the AES-ECB data to work with. */
     aes = (we_AesBlock *)EVP_CIPHER_CTX_get_cipher_data(ctx);
     if (aes != NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("EVP_CIPHER_CTX_get_cipher_data", aes);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER,
+                                   "EVP_CIPHER_CTX_get_cipher_data", aes);
         ret = 0;
     }
     if (ret == 1) {
@@ -969,13 +994,13 @@ static int we_aes_ecb_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
             default:
                 XSNPRINTF(errBuff, sizeof(errBuff), "Unsupported ctrl type %d",
                           type);
-                WOLFENGINE_ERROR_MSG(errBuff);
+                WOLFENGINE_ERROR_MSG(WE_LOG_CIPHER, errBuff);
                 ret = 0;
                 break;
         }
     }
 
-    WOLFENGINE_LEAVE("we_aes_ecb_ctrl", ret);
+    WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_aes_ecb_ctrl", ret);
 
     return ret;
 }
@@ -1004,7 +1029,7 @@ static int we_init_aesecb_meth(EVP_CIPHER *cipher)
 {
     int ret;
 
-    WOLFENGINE_ENTER("we_init_aesecb_meth");
+    WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_init_aesecb_meth");
 
     ret = EVP_CIPHER_meth_set_iv_length(cipher, 0);
     if (ret == 1) {
@@ -1023,7 +1048,7 @@ static int we_init_aesecb_meth(EVP_CIPHER *cipher)
         ret = EVP_CIPHER_meth_set_impl_ctx_size(cipher, sizeof(we_AesBlock));
     }
 
-    WOLFENGINE_LEAVE("we_init_aesecb_meth", ret);
+    WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_init_aesecb_meth", ret);
 
     return ret;
 }
@@ -1037,13 +1062,14 @@ int we_init_aesecb_meths()
 {
     int ret = 1;
 
-    WOLFENGINE_ENTER("we_init_aesecb_meths");
+    WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_init_aesecb_meths");
 
     /* AES128-ECB */
     we_aes128_ecb_ciph = EVP_CIPHER_meth_new(NID_aes_128_ecb, AES_BLOCK_SIZE,
                                              AES_128_KEY_SIZE);
     if (we_aes128_ecb_ciph == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("EVP_CIPHER_meth_new - AES-128-ECB",
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER,
+                                   "EVP_CIPHER_meth_new - AES-128-ECB",
                                    we_aes128_ecb_ciph);
         ret = 0;
     }
@@ -1056,7 +1082,8 @@ int we_init_aesecb_meths()
         we_aes192_ecb_ciph = EVP_CIPHER_meth_new(NID_aes_192_ecb,
             AES_BLOCK_SIZE, AES_192_KEY_SIZE);
         if (we_aes192_ecb_ciph == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("EVP_CIPHER_meth_new - AES-192-ECB",
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER,
+                                       "EVP_CIPHER_meth_new - AES-192-ECB",
                                        we_aes192_ecb_ciph);
             ret = 0;
         }
@@ -1070,7 +1097,8 @@ int we_init_aesecb_meths()
         we_aes256_ecb_ciph = EVP_CIPHER_meth_new(NID_aes_256_ecb,
             AES_BLOCK_SIZE, AES_256_KEY_SIZE);
         if (we_aes256_ecb_ciph == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("EVP_CIPHER_meth_new - AES-256-ECB",
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER,
+                                       "EVP_CIPHER_meth_new - AES-256-ECB",
                                        we_aes256_ecb_ciph);
             ret = 0;
         }
@@ -1093,7 +1121,7 @@ int we_init_aesecb_meths()
         we_aes256_ecb_ciph = NULL;
     }
 
-    WOLFENGINE_LEAVE("we_init_aesecb_meths", ret);
+    WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_init_aesecb_meths", ret);
 
     return ret;
 }

--- a/src/aes_cbc_hmac.c
+++ b/src/aes_cbc_hmac.c
@@ -64,7 +64,7 @@ static int we_aes_cbc_hmac_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
     int rc;
     we_AesCbcHmac *aes;
 
-    WOLFENGINE_ENTER("we_aes_cbc_hmac_init");
+    WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_aes_cbc_hmac_init");
 
     if ((iv == NULL) && (key == NULL)) {
         ret = 0;
@@ -73,7 +73,8 @@ static int we_aes_cbc_hmac_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
     if (ret == 1) {
         aes = (we_AesCbcHmac *)EVP_CIPHER_CTX_get_cipher_data(ctx);
         if (aes == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("EVP_CIPHER_CTX_get_cipher_data", aes);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER,
+                                       "EVP_CIPHER_CTX_get_cipher_data", aes);
             ret = 0;
         }
     }
@@ -82,7 +83,7 @@ static int we_aes_cbc_hmac_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
     if ((ret == 1) && (!aes->init)) {
         rc = wc_AesInit(&aes->aes, NULL, INVALID_DEVID);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_AesInit", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER, "wc_AesInit", rc);
             ret = 0;
         }
     }
@@ -90,7 +91,7 @@ static int we_aes_cbc_hmac_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
     if ((ret == 1) && (!aes->init)) {
         rc = wc_HmacInit(&aes->hmac, NULL, INVALID_DEVID);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_HmacInit", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER, "wc_HmacInit", rc);
             ret = 0;
         }
     }
@@ -108,7 +109,7 @@ static int we_aes_cbc_hmac_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
             rc = wc_AesSetKey(&aes->aes, key, EVP_CIPHER_CTX_key_length(ctx),
                               iv, enc ? AES_ENCRYPTION : AES_DECRYPTION);
             if (rc != 0) {
-                WOLFENGINE_ERROR_FUNC("wc_AesSetKey", rc);
+                WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER, "wc_AesSetKey", rc);
                 ret = 0;
             }
         }
@@ -116,13 +117,13 @@ static int we_aes_cbc_hmac_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
             /* Set the IV into wolfSSL AES object. */
             rc = wc_AesSetIV(&aes->aes, iv);
             if (rc != 0) {
-                WOLFENGINE_ERROR_FUNC("wc_AesSetIV", rc);
+                WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER, "wc_AesSetIV", rc);
                 ret = 0;
             }
         }
     }
 
-    WOLFENGINE_LEAVE("we_aes_cbc_hmac_init", ret);
+    WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_aes_cbc_hmac_init", ret);
 
     return ret;
 }
@@ -158,7 +159,7 @@ static int we_aes_cbc_hmac_enc(we_AesCbcHmac* aes, unsigned char *out,
         off = AES_BLOCK_SIZE;
         rc = wc_AesSetIV(&aes->aes, in);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_AesSetIV", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER, "wc_AesSetIV", rc);
             ret = -1;
         }
     }
@@ -167,7 +168,7 @@ static int we_aes_cbc_hmac_enc(we_AesCbcHmac* aes, unsigned char *out,
         /* MAC the handshake message/data. */
         rc = wc_HmacUpdate(&aes->hmac, in + off, pLen - off);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_HmacUpdate", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER, "wc_HmacUpdate", rc);
             ret = -1;
         }
     }
@@ -178,7 +179,7 @@ static int we_aes_cbc_hmac_enc(we_AesCbcHmac* aes, unsigned char *out,
         /* Put the MAC after data. */
         rc = wc_HmacFinal(&aes->hmac, out + pLen);
         if (rc != 0) {
-             WOLFENGINE_ERROR_FUNC("wc_HmacFinal", rc);
+             WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER, "wc_HmacFinal", rc);
              ret = -1;
         }
     }
@@ -195,7 +196,7 @@ static int we_aes_cbc_hmac_enc(we_AesCbcHmac* aes, unsigned char *out,
         /* Encrypt the msg and MAC but not IV. */
         rc = wc_AesCbcEncrypt(&aes->aes, out + off, in + off, (int)len - off);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_AesCbcEncrypt", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER, "wc_AesCbcEncrypt", rc);
             ret = 0;
         }
         else {
@@ -236,7 +237,7 @@ static int we_aes_cbc_hmac_dec(we_AesCbcHmac* aes, unsigned char *out,
         off = AES_BLOCK_SIZE;
         rc = wc_AesSetIV(&aes->aes, in);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_AesSetIV", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER, "wc_AesSetIV", rc);
             ret = -1;
        }
     }
@@ -244,7 +245,7 @@ static int we_aes_cbc_hmac_dec(we_AesCbcHmac* aes, unsigned char *out,
         /* Decrypt all but IV. */
         rc = wc_AesCbcDecrypt(&aes->aes, out + off, in + off, (int)len - off);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_AesCbcDecrypt", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER, "wc_AesCbcDecrypt", rc);
             ret = -1;
         }
         else {
@@ -275,7 +276,7 @@ static int we_aes_cbc_hmac_dec(we_AesCbcHmac* aes, unsigned char *out,
         /* MAC the record header. */
         rc = wc_HmacUpdate(&aes->hmac, aes->tlsAAD, aes->pLen);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_HmacUpdate", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER, "wc_HmacUpdate", rc);
             ret = -1;
         }
     }
@@ -284,7 +285,7 @@ static int we_aes_cbc_hmac_dec(we_AesCbcHmac* aes, unsigned char *out,
         /* MAC the message/input. */
         rc = wc_HmacUpdate(&aes->hmac, out + off, ret);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_HmacUpdate", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER, "wc_HmacUpdate", rc);
             ret = -1;
         }
     }
@@ -292,7 +293,7 @@ static int we_aes_cbc_hmac_dec(we_AesCbcHmac* aes, unsigned char *out,
         /* Calculate MAC. */
         rc = wc_HmacFinal(&aes->hmac, mac);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_HmacFinal", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER, "wc_HmacFinal", rc);
             ret = -1;
         }
     }
@@ -329,12 +330,13 @@ static int we_aes_cbc_hmac_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
     we_AesCbcHmac* aes;
 
 
-    WOLFENGINE_ENTER("we_aes_cbc_hmac_cipher");
+    WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_aes_cbc_hmac_cipher");
 
     /* Get the AES-CBC object to work with. */
     aes = (we_AesCbcHmac *)EVP_CIPHER_CTX_get_cipher_data(ctx);
     if (aes == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("EVP_CIPHER_CTX_get_cipher_data", aes);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER,
+                                   "EVP_CIPHER_CTX_get_cipher_data", aes);
         ret = -1;
     }
     else if (aes->enc) {
@@ -344,7 +346,7 @@ static int we_aes_cbc_hmac_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
         ret = we_aes_cbc_hmac_dec(aes, out, in, len);
     }
 
-    WOLFENGINE_LEAVE("we_aes_cbc_hmac_cipher", ret);
+    WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_aes_cbc_hmac_cipher", ret);
 
     return ret;
 }
@@ -371,7 +373,7 @@ static int we_aes_cbc_hmac_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg,
     int len;
     char errBuff[WOLFENGINE_MAX_ERROR_SZ];
 
-    WOLFENGINE_ENTER("we_aes_cbc_hmac_ctrl");
+    WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_aes_cbc_hmac_ctrl");
 
     (void)arg;
     (void)ptr;
@@ -379,7 +381,8 @@ static int we_aes_cbc_hmac_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg,
     /* Get the AES-CBC data to work with. */
     aes = (we_AesCbcHmac *)EVP_CIPHER_CTX_get_cipher_data(ctx);
     if (aes == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("EVP_CIPHER_CTX_get_cipher_data", aes);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER,
+                                   "EVP_CIPHER_CTX_get_cipher_data", aes);
         ret = 0;
     }
     if (ret == 1) {
@@ -388,7 +391,7 @@ static int we_aes_cbc_hmac_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg,
                 /* Set the HMAC key. */
                 rc = wc_HmacSetKey(&aes->hmac, WC_SHA256, ptr, arg);
                 if (rc != 0) {
-                    WOLFENGINE_ERROR_FUNC("wc_HmacSetKey", rc);
+                    WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER, "wc_HmacSetKey", rc);
                     ret = 0;
                 }
                 break;
@@ -424,7 +427,8 @@ static int we_aes_cbc_hmac_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg,
                             /* MAC the record header. */
                             rc = wc_HmacUpdate(&aes->hmac, tls, arg);
                             if (rc != 0) {
-                                WOLFENGINE_ERROR_FUNC("wc_HmacUpdate", rc);
+                                WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER,
+                                                      "wc_HmacUpdate", rc);
                                 ret = -1;
                             }
                         }
@@ -446,13 +450,13 @@ static int we_aes_cbc_hmac_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg,
             default:
                 XSNPRINTF(errBuff, sizeof(errBuff), "Unsupported ctrl type %d",
                           type);
-                WOLFENGINE_ERROR_MSG(errBuff);
+                WOLFENGINE_ERROR_MSG(WE_LOG_CIPHER, errBuff);
                 ret = 0;
                 break;
         }
     }
 
-    WOLFENGINE_LEAVE("we_aes_cbc_hmac_ctrl", ret);
+    WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_aes_cbc_hmac_ctrl", ret);
 
     return ret;
 }
@@ -480,7 +484,7 @@ static int we_init_aescbc_hmac_meth(EVP_CIPHER *cipher)
 {
     int ret;
 
-    WOLFENGINE_ENTER("we_init_aescbc_meth");
+    WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_init_aescbc_meth");
 
     ret = EVP_CIPHER_meth_set_iv_length(cipher, AES_IV_SIZE);
     if (ret == 1) {
@@ -499,7 +503,7 @@ static int we_init_aescbc_hmac_meth(EVP_CIPHER *cipher)
         ret = EVP_CIPHER_meth_set_impl_ctx_size(cipher, sizeof(we_AesCbcHmac));
     }
 
-    WOLFENGINE_LEAVE("we_init_aescbc_meth", ret);
+    WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_init_aescbc_meth", ret);
 
     return ret;
 }
@@ -513,13 +517,14 @@ int we_init_aescbc_hmac_meths()
 {
     int ret = 1;
 
-    WOLFENGINE_ENTER("we_init_aescbc_meths");
+    WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_init_aescbc_meths");
 
     /* AES128-CBC HMAC-SHA256 */
     we_aes128_cbc_hmac_ciph = EVP_CIPHER_meth_new(NID_aes_128_cbc_hmac_sha256,
         AES_BLOCK_SIZE, AES_128_KEY_SIZE);
     if (we_aes128_cbc_ciph == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("EVP_CIPHER_meth_new - AES-128-CBC "
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER,
+                                   "EVP_CIPHER_meth_new - AES-128-CBC "
                                    "HMAC SHA256", we_aes128_cbc_ciph);
         ret = 0;
     }
@@ -532,7 +537,8 @@ int we_init_aescbc_hmac_meths()
         we_aes256_cbc_hmac_ciph = EVP_CIPHER_meth_new(
             NID_aes_256_cbc_hmac_sha256, AES_BLOCK_SIZE, AES_256_KEY_SIZE);
         if (we_aes256_cbc_ciph == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("EVP_CIPHER_meth_new - AES-256-CBC "
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER,
+                                       "EVP_CIPHER_meth_new - AES-256-CBC "
                                        "HMAC SHA256", we_aes256_cbc_ciph);
             ret = 0;
         }
@@ -551,7 +557,7 @@ int we_init_aescbc_hmac_meths()
         we_aes256_cbc_hmac_ciph = NULL;
     }
 
-    WOLFENGINE_LEAVE("we_init_aescbc_meths", ret);
+    WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_init_aescbc_meths", ret);
 
     return ret;
 }

--- a/src/aes_ccm.c
+++ b/src/aes_ccm.c
@@ -96,12 +96,13 @@ static int we_aes_ccm_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
     int rc;
     we_AesCcm *aes;
 
-    WOLFENGINE_ENTER("we_aes_ccm_init");
+    WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_aes_ccm_init");
 
     /* Get the internal AES-CCM object. */
     aes = (we_AesCcm *)EVP_CIPHER_CTX_get_cipher_data(ctx);
     if (aes == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("EVP_CIPHER_CTX_get_cipher_data", aes);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER,
+                                   "EVP_CIPHER_CTX_get_cipher_data", aes);
         ret = 0;
     }
 
@@ -124,7 +125,7 @@ static int we_aes_ccm_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
         /* Set the AES-CCM key. */
         rc = wc_AesCcmSetKey(&aes->aes, key, EVP_CIPHER_CTX_key_length(ctx));
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_AesCcmSetKey", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER, "wc_AesCcmSetKey", rc);
             ret = 0;
         }
     }
@@ -134,7 +135,7 @@ static int we_aes_ccm_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
         XMEMCPY(aes->iv, iv, CCM_NONCE_MAX_SZ);
     }
 
-    WOLFENGINE_LEAVE("we_aes_ccm_init", ret);
+    WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_aes_ccm_init", ret);
 
     return ret;
 }
@@ -170,7 +171,7 @@ static int we_aes_ccm_tls_cipher(we_AesCcm *aes, unsigned char *out,
             /* Set Nonce/IV. */
             rc = wc_AesCcmSetNonce(&aes->aes, aes->iv, aes->ivLen);
             if (rc != 0) {
-                WOLFENGINE_ERROR_FUNC("wc_AesCcmSetExtIV", rc);
+                WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER, "wc_AesCcmSetExtIV", rc);
                 ret = 0;
             }
             aes->ivSet = 1;
@@ -191,7 +192,7 @@ static int we_aes_ccm_tls_cipher(we_AesCcm *aes, unsigned char *out,
                                      EVP_CCM_TLS_TAG_LEN, aes->aad,
                                      aes->aadLen);
             if (rc != 0) {
-                WOLFENGINE_ERROR_FUNC("wc_AesCcmEncrypt_ex", rc);
+                WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER, "wc_AesCcmEncrypt_ex", rc);
                 ret = 0;
             }
         }
@@ -218,7 +219,7 @@ static int we_aes_ccm_tls_cipher(we_AesCcm *aes, unsigned char *out,
                                   in + len - EVP_CCM_TLS_TAG_LEN,
                                   EVP_CCM_TLS_TAG_LEN, aes->aad, aes->aadLen);
             if (rc != 0) {
-                WOLFENGINE_ERROR_FUNC("wc_AesCcmDecrypt", rc);
+                WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER, "wc_AesCcmDecrypt", rc);
                 ret = 0;
             }
         }
@@ -261,12 +262,13 @@ static int we_aes_ccm_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
     we_AesCcm *aes;
     unsigned char *p;
 
-    WOLFENGINE_ENTER("we_aes_ccm_cipher");
+    WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_aes_ccm_cipher");
 
     /* Get the AES-CCM data to work with. */
     aes = (we_AesCcm *)EVP_CIPHER_CTX_get_cipher_data(ctx);
     if (aes == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("EVP_CIPHER_CTX_get_cipher_data", aes);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER,
+                                   "EVP_CIPHER_CTX_get_cipher_data", aes);
         ret = 0;
     }
 
@@ -280,7 +282,7 @@ static int we_aes_ccm_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
         /* Resize stored AAD and append new data. */
         p = OPENSSL_realloc(aes->aad, aes->aadLen + (int)len);
         if (p == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("OPENSSL_realloc", p);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER, "OPENSSL_realloc", p);
             ret = 0;
         }
         else {
@@ -296,7 +298,8 @@ static int we_aes_ccm_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
                 /* Set extern IV. */
                 rc = wc_AesCcmSetNonce(&aes->aes, aes->iv, aes->ivLen);
                 if (rc != 0) {
-                    WOLFENGINE_ERROR_FUNC("wc_AesCcmSetExtIV", rc);
+                    WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER,
+                                          "wc_AesCcmSetExtIV", rc);
                     ret = 0;
                 }
             }
@@ -308,7 +311,8 @@ static int we_aes_ccm_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
                                          aes->iv, aes->ivLen, aes->tag,
                                          aes->tagLen, aes->aad, aes->aadLen);
                 if (rc != 0) {
-                    WOLFENGINE_ERROR_FUNC("wc_AesCcmEncrypt_ex", rc);
+                    WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER,
+                                          "wc_AesCcmEncrypt_ex", rc);
                     ret = 0;
                 }
             }
@@ -323,7 +327,7 @@ static int we_aes_ccm_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
                                   aes->ivLen, aes->tag, aes->tagLen,
                                   aes->aad, aes->aadLen);
             if (rc != 0) {
-                WOLFENGINE_ERROR_FUNC("wc_AesCcmDecrypt_ex", rc);
+                WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER, "wc_AesCcmDecrypt_ex", rc);
                 ret = 0;
             }
             if (ret == 1) {
@@ -338,7 +342,7 @@ static int we_aes_ccm_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
         aes->aadLen = 0;
     }
 
-    WOLFENGINE_LEAVE("we_aes_ccm_cipher", ret);
+    WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_aes_ccm_cipher", ret);
 
     return ret;
 }
@@ -367,24 +371,25 @@ static int we_aes_ccm_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
     we_AesCcm *aes;
     char errBuff[WOLFENGINE_MAX_ERROR_SZ];
 
-    WOLFENGINE_ENTER("we_aes_ccm_ctrl");
+    WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_aes_ccm_ctrl");
 
     /* Get the AES-CCM data to work with. */
     aes = (we_AesCcm *)EVP_CIPHER_CTX_get_cipher_data(ctx);
     if (aes == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("EVP_CIPHER_CTX_get_cipher_data", aes);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER,
+                                   "EVP_CIPHER_CTX_get_cipher_data", aes);
         ret = 0;
     }
     if (ret == 1) {
         switch (type) {
             case EVP_CTRL_AEAD_SET_IVLEN:
-                WOLFENGINE_MSG("EVP_CTRL_AEAD_SET_IVLEN");
+                WOLFENGINE_MSG(WE_LOG_CIPHER, "EVP_CTRL_AEAD_SET_IVLEN");
                 /* Set the IV/nonce length to use
                  *   arg [in] length of IV/nonce to use
                  *   ptr [in] Unused
                  */
                 if ((arg <= 0) || (arg > CCM_NONCE_MAX_SZ)) {
-                    WOLFENGINE_ERROR_MSG("Invalid nonce length");
+                    WOLFENGINE_ERROR_MSG(WE_LOG_CIPHER, "Invalid nonce length");
                     ret = 0;
                 }
                 else {
@@ -393,7 +398,7 @@ static int we_aes_ccm_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
                 break;
 
             case EVP_CTRL_GET_IVLEN:
-                WOLFENGINE_MSG("EVP_CTRL_GET_IVLEN");
+                WOLFENGINE_MSG(WE_LOG_CIPHER, "EVP_CTRL_GET_IVLEN");
                 /* Set the generated IV
                  *   ptr [out] length of iv
                  */
@@ -401,7 +406,7 @@ static int we_aes_ccm_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
                 break;
 
             case EVP_CTRL_CCM_SET_IV_FIXED:
-                WOLFENGINE_MSG("EVP_CTRL_CCM_SET_IV_FIXED");
+                WOLFENGINE_MSG(WE_LOG_CIPHER, "EVP_CTRL_CCM_SET_IV_FIXED");
                 /* Set the fixed part of an IV
                  *   arg [in] size of fixed part of IV/nonce
                  *   ptr [in] fixed part of IV/nonce data
@@ -416,7 +421,7 @@ static int we_aes_ccm_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
                 break;
 
             case EVP_CTRL_AEAD_GET_TAG:
-                WOLFENGINE_MSG("EVP_CTRL_AEAD_GET_TAG");
+                WOLFENGINE_MSG(WE_LOG_CIPHER, "EVP_CTRL_AEAD_GET_TAG");
                 /* Get the tag from encryption.
                  *   arg [in] size of buffer
                  *   ptr [in] buffer to copy into
@@ -430,13 +435,13 @@ static int we_aes_ccm_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
                 break;
 
             case EVP_CTRL_AEAD_SET_TAG:
-                WOLFENGINE_MSG("EVP_CTRL_AEAD_SET_TAG");
+                WOLFENGINE_MSG(WE_LOG_CIPHER, "EVP_CTRL_AEAD_SET_TAG");
                 /* Set the tag for decryption.
                  *   arg [in] size of tag
                  *   ptr [in] tag data to copy
                  */
                 if ((arg <= 0) || (arg > AES_BLOCK_SIZE)) {
-                    WOLFENGINE_ERROR_MSG("Invalid tag size");
+                    WOLFENGINE_ERROR_MSG(WE_LOG_CIPHER, "Invalid tag size");
                     ret = 0;
                 }
                 else {
@@ -454,7 +459,7 @@ static int we_aes_ccm_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
                  *   ptr [in] AAD to use
                  */
                 if (arg != EVP_AEAD_TLS1_AAD_LEN) {
-                    WOLFENGINE_ERROR_MSG("Invalid TLS AAD size");
+                    WOLFENGINE_ERROR_MSG(WE_LOG_CIPHER, "Invalid TLS AAD size");
                     ret = 0;
                 }
                 if (ret == 1) {
@@ -466,7 +471,8 @@ static int we_aes_ccm_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
                     }
                     aes->aad = OPENSSL_malloc(arg);
                     if (aes->aad == NULL) {
-                        WOLFENGINE_ERROR_FUNC_NULL("OPENSSL_malloc", aes->aad);
+                        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER,
+                                                   "OPENSSL_malloc", aes->aad);
                         ret = 0;
                     }
                     if (ret == 1) {
@@ -475,7 +481,8 @@ static int we_aes_ccm_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
                         /* Get last two bytes of AAD. */
                         len = (aes->aad[arg - 2] << 8) | aes->aad[arg - 1];
                         if (len < EVP_CCM_TLS_EXPLICIT_IV_LEN) {
-                            WOLFENGINE_ERROR_MSG("Length in AAD invalid");
+                            WOLFENGINE_ERROR_MSG(WE_LOG_CIPHER,
+                                                 "Length in AAD invalid");
                             ret = 0;
                         }
                     }
@@ -483,7 +490,8 @@ static int we_aes_ccm_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
                         len -= EVP_CCM_TLS_EXPLICIT_IV_LEN;
                         if (!aes->enc) {
                             if (len < EVP_CCM_TLS_TAG_LEN) {
-                                WOLFENGINE_ERROR_MSG("Length in AAD invalid");
+                                WOLFENGINE_ERROR_MSG(WE_LOG_CIPHER,
+                                                     "Length in AAD invalid");
                                 ret = 0;
                             }
                             else {
@@ -505,13 +513,13 @@ static int we_aes_ccm_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
             default:
                 XSNPRINTF(errBuff, sizeof(errBuff), "Unsupported ctrl type %d",
                           type);
-                WOLFENGINE_ERROR_MSG(errBuff);
+                WOLFENGINE_ERROR_MSG(WE_LOG_CIPHER, errBuff);
                 ret = 0;
                 break;
         }
     }
 
-    WOLFENGINE_LEAVE("we_aes_ccm_ctrl", ret);
+    WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_aes_ccm_ctrl", ret);
 
     return ret;
 }
@@ -543,7 +551,7 @@ static int we_init_aesccm_meth(EVP_CIPHER *cipher)
 {
     int ret;
 
-    WOLFENGINE_ENTER("we_init_aesccm_meth");
+    WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_init_aesccm_meth");
 
     ret = EVP_CIPHER_meth_set_iv_length(cipher, CCM_NONCE_MAX_SZ);
     if (ret == 1) {
@@ -562,7 +570,7 @@ static int we_init_aesccm_meth(EVP_CIPHER *cipher)
         ret = EVP_CIPHER_meth_set_impl_ctx_size(cipher, sizeof(we_AesCcm));
     }
 
-    WOLFENGINE_LEAVE("we_init_aesccm_meth", ret);
+    WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_init_aesccm_meth", ret);
 
     return ret;
 }
@@ -576,13 +584,14 @@ int we_init_aesccm_meths()
 {
     int ret = 1;
 
-    WOLFENGINE_ENTER("we_init_aesccm_meths");
+    WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_init_aesccm_meths");
 
     /* AES128-CCM */
     we_aes128_ccm_ciph = EVP_CIPHER_meth_new(NID_aes_128_ccm, 1,
                                              AES_128_KEY_SIZE);
     if (we_aes128_ccm_ciph == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("EVP_CIPHER_meth_new - AES-128-CCM",
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER,
+                                   "EVP_CIPHER_meth_new - AES-128-CCM",
                                    we_aes128_ccm_ciph);
         ret = 0;
     }
@@ -595,7 +604,8 @@ int we_init_aesccm_meths()
         we_aes192_ccm_ciph = EVP_CIPHER_meth_new(NID_aes_192_ccm, 1,
                                                  AES_192_KEY_SIZE);
         if (we_aes192_ccm_ciph == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("EVP_CIPHER_meth_new - AES-192-CCM",
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER,
+                                       "EVP_CIPHER_meth_new - AES-192-CCM",
                                        we_aes192_ccm_ciph);
             ret = 0;
         }
@@ -609,7 +619,8 @@ int we_init_aesccm_meths()
         we_aes256_ccm_ciph = EVP_CIPHER_meth_new(NID_aes_256_ccm, 1,
                                                  AES_256_KEY_SIZE);
         if (we_aes256_ccm_ciph == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("EVP_CIPHER_meth_new - AES-256-CCM",
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER,
+                                       "EVP_CIPHER_meth_new - AES-256-CCM",
                                        we_aes256_ccm_ciph);
             ret = 0;
         }
@@ -632,7 +643,7 @@ int we_init_aesccm_meths()
         we_aes256_ccm_ciph = NULL;
     }
 
-    WOLFENGINE_LEAVE("we_init_aesccm_meths", ret);
+    WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_init_aesccm_meths", ret);
 
     return ret;
 }

--- a/src/aes_ctr.c
+++ b/src/aes_ctr.c
@@ -55,20 +55,21 @@ static int we_aes_ctr_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
     int rc;
     we_AesCtr *aes;
 
-    WOLFENGINE_ENTER("we_aes_ctr_init");
+    WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_aes_ctr_init");
 
     (void)enc;
 
     aes = (we_AesCtr *)EVP_CIPHER_CTX_get_cipher_data(ctx);
     if (aes == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("EVP_CIPHER_CTX_get_cipher_data", aes);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER,
+                                   "EVP_CIPHER_CTX_get_cipher_data", aes);
         ret = 0;
     }
 
     if ((ret == 1) && (((key == NULL) && (iv == NULL)) || (!aes->init))) {
         rc = wc_AesInit(&aes->aes, NULL, INVALID_DEVID);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_AesInit", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER, "wc_AesInit", rc);
             ret = 0;
         }
     }
@@ -82,20 +83,20 @@ static int we_aes_ctr_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
             rc = wc_AesSetKey(&aes->aes, key, EVP_CIPHER_CTX_key_length(ctx),
                               iv, AES_ENCRYPTION);
             if (rc != 0) {
-                WOLFENGINE_ERROR_FUNC("wc_AesSetKey", rc);
+                WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER, "wc_AesSetKey", rc);
                 ret = 0;
             }
         }
         if (iv != NULL) {
             rc = wc_AesSetIV(&aes->aes, iv);
             if (rc != 0) {
-                WOLFENGINE_ERROR_FUNC("wc_AesSetIV", rc);
+                WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER, "wc_AesSetIV", rc);
                 ret = 0;
             }
         }
     }
 
-    WOLFENGINE_LEAVE("we_aes_ctr_init", ret);
+    WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_aes_ctr_init", ret);
 
     return ret;
 }
@@ -119,23 +120,24 @@ static int we_aes_ctr_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
     we_AesCtr* aes;
     int rc;
 
-    WOLFENGINE_ENTER("we_aes_ctr_cipher");
+    WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_aes_ctr_cipher");
 
     /* Get the AES-CTR object to work with. */
     aes = (we_AesCtr *)EVP_CIPHER_CTX_get_cipher_data(ctx);
     if (aes == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("EVP_CIPHER_CTX_get_cipher_data", aes);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER,
+                                   "EVP_CIPHER_CTX_get_cipher_data", aes);
         ret = -1;
     }
     if ((ret == (int)len) && (len != 0)) {
         rc = wc_AesCtrEncrypt(&aes->aes, out, in, (word32)len);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_AesCtrEncrypt", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER, "wc_AesCtrEncrypt", rc);
             ret = -1;
         }
     }
 
-    WOLFENGINE_LEAVE("we_aes_ctr_cipher", ret);
+    WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_aes_ctr_cipher", ret);
 
     return ret;
 }
@@ -157,7 +159,7 @@ static int we_aes_ctr_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
     we_AesCtr *aes;
     char errBuff[WOLFENGINE_MAX_ERROR_SZ];
 
-    WOLFENGINE_ENTER("we_aes_ctr_ctrl");
+    WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_aes_ctr_ctrl");
 
     (void)arg;
     (void)ptr;
@@ -165,7 +167,8 @@ static int we_aes_ctr_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
     /* Get the AES-CTR data to work with. */
     aes = (we_AesCtr *)EVP_CIPHER_CTX_get_cipher_data(ctx);
     if (aes != NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("EVP_CIPHER_CTX_get_cipher_data", aes);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER,
+                                   "EVP_CIPHER_CTX_get_cipher_data", aes);
         ret = 0;
     }
     if (ret == 1) {
@@ -173,13 +176,13 @@ static int we_aes_ctr_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
             default:
                 XSNPRINTF(errBuff, sizeof(errBuff), "Unsupported ctrl type %d",
                           type);
-                WOLFENGINE_ERROR_MSG(errBuff);
+                WOLFENGINE_ERROR_MSG(WE_LOG_CIPHER, errBuff);
                 ret = 0;
                 break;
         }
     }
 
-    WOLFENGINE_LEAVE("we_aes_ctr_ctrl", ret);
+    WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_aes_ctr_ctrl", ret);
 
     return ret;
 }
@@ -208,7 +211,7 @@ static int we_init_aesctr_meth(EVP_CIPHER *cipher)
 {
     int ret;
 
-    WOLFENGINE_ENTER("we_init_aesctr_meth");
+    WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_init_aesctr_meth");
 
     ret = EVP_CIPHER_meth_set_iv_length(cipher, AES_IV_SIZE);
     if (ret == 1) {
@@ -227,7 +230,7 @@ static int we_init_aesctr_meth(EVP_CIPHER *cipher)
         ret = EVP_CIPHER_meth_set_impl_ctx_size(cipher, sizeof(we_AesCtr));
     }
 
-    WOLFENGINE_LEAVE("we_init_aesctr_meth", ret);
+    WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_init_aesctr_meth", ret);
 
     return ret;
 }
@@ -241,13 +244,14 @@ int we_init_aesctr_meths()
 {
     int ret = 1;
 
-    WOLFENGINE_ENTER("we_init_aesctr_meths");
+    WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_init_aesctr_meths");
 
     /* AES128-CTR */
     we_aes128_ctr_ciph = EVP_CIPHER_meth_new(NID_aes_128_ctr, 1,
                                              AES_128_KEY_SIZE);
     if (we_aes128_ctr_ciph == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("EVP_CIPHER_meth_new - AES-128-CTR",
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER,
+                                   "EVP_CIPHER_meth_new - AES-128-CTR",
                                    we_aes128_ctr_ciph);
         ret = 0;
     }
@@ -260,7 +264,8 @@ int we_init_aesctr_meths()
         we_aes192_ctr_ciph = EVP_CIPHER_meth_new(NID_aes_192_ctr, 1,
                                                  AES_192_KEY_SIZE);
         if (we_aes192_ctr_ciph == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("EVP_CIPHER_meth_new - AES-192-CTR",
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER,
+                                       "EVP_CIPHER_meth_new - AES-192-CTR",
                                        we_aes192_ctr_ciph);
             ret = 0;
         }
@@ -274,7 +279,8 @@ int we_init_aesctr_meths()
         we_aes256_ctr_ciph = EVP_CIPHER_meth_new(NID_aes_256_ctr, 1,
                                                  AES_256_KEY_SIZE);
         if (we_aes256_ctr_ciph == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("EVP_CIPHER_meth_new - AES-256-CTR",
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER,
+                                       "EVP_CIPHER_meth_new - AES-256-CTR",
                                        we_aes256_ctr_ciph);
             ret = 0;
         }
@@ -297,7 +303,7 @@ int we_init_aesctr_meths()
         we_aes256_ctr_ciph = NULL;
     }
 
-    WOLFENGINE_LEAVE("we_init_aesctr_meths", ret);
+    WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_init_aesctr_meths", ret);
 
     return ret;
 }

--- a/src/aes_gcm.c
+++ b/src/aes_gcm.c
@@ -82,12 +82,13 @@ static int we_aes_gcm_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
     int rc;
     we_AesGcm *aes;
 
-    WOLFENGINE_ENTER("we_aes_gcm_init");
+    WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_aes_gcm_init");
 
     /* Get the internal AES-GCM object. */
     aes = (we_AesGcm *)EVP_CIPHER_CTX_get_cipher_data(ctx);
     if (aes == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("EVP_CIPHER_CTX_get_cipher_data", aes);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER,
+                                   "EVP_CIPHER_CTX_get_cipher_data", aes);
         ret = 0;
     }
 
@@ -95,7 +96,7 @@ static int we_aes_gcm_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
         /* Set the AES-GCM key. */
         rc = wc_AesGcmSetKey(&aes->aes, key, EVP_CIPHER_CTX_key_length(ctx));
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_AesGcmSetKey", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER, "wc_AesGcmSetKey", rc);
             ret = 0;
         }
     }
@@ -109,7 +110,7 @@ static int we_aes_gcm_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
         aes->enc = enc;
     }
 
-    WOLFENGINE_LEAVE("we_aes_gcm_init", ret);
+    WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_aes_gcm_init", ret);
 
     return ret;
 }
@@ -139,7 +140,7 @@ static int we_aes_gcm_tls_cipher(we_AesGcm *aes, unsigned char *out,
                                   out + len - EVP_GCM_TLS_TAG_LEN,
                                   EVP_GCM_TLS_TAG_LEN, aes->aad, aes->aadLen);
             if (rc != 0) {
-                WOLFENGINE_ERROR_FUNC("wc_AesGcmEncrypt_ex", rc);
+                WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER, "wc_AesGcmEncrypt_ex", rc);
                 ret = 0;
             }
         }
@@ -166,7 +167,7 @@ static int we_aes_gcm_tls_cipher(we_AesGcm *aes, unsigned char *out,
                                   in + len - EVP_GCM_TLS_TAG_LEN,
                                   EVP_GCM_TLS_TAG_LEN, aes->aad, aes->aadLen);
             if (rc != 0) {
-                WOLFENGINE_ERROR_FUNC("wc_AesGcmDecrypt", rc);
+                WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER, "wc_AesGcmDecrypt", rc);
                 ret = 0;
             }
         }
@@ -209,12 +210,13 @@ static int we_aes_gcm_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
     we_AesGcm *aes;
     unsigned char *p;
 
-    WOLFENGINE_ENTER("we_aes_gcm_cipher");
+    WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_aes_gcm_cipher");
 
     /* Get the AES-GCM data to work with. */
     aes = (we_AesGcm *)EVP_CIPHER_CTX_get_cipher_data(ctx);
     if (aes == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("EVP_CIPHER_CTX_get_cipher_data", aes);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER,
+                                   "EVP_CIPHER_CTX_get_cipher_data", aes);
         ret = 0;
     }
 
@@ -225,7 +227,7 @@ static int we_aes_gcm_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
         /* Resize stored AAD and append new data. */
         p = OPENSSL_realloc(aes->aad, aes->aadLen + (int)len);
         if (p == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("OPENSSL_realloc", p);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER, "OPENSSL_realloc", p);
             ret = 0;
         }
         else {
@@ -246,7 +248,8 @@ static int we_aes_gcm_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
                 /* Set extern IV. */
                 rc = wc_AesGcmSetExtIV(&aes->aes, aes->iv, aes->ivLen);
                 if (rc != 0) {
-                    WOLFENGINE_ERROR_FUNC("wc_AesGcmSetExtIV", rc);
+                    WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER,
+                                          "wc_AesGcmSetExtIV", rc);
                     ret = 0;
                 }
             }
@@ -258,7 +261,8 @@ static int we_aes_gcm_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
                                          aes->iv, aes->ivLen, aes->tag,
                                          aes->tagLen, aes->aad, aes->aadLen);
                 if (rc != 0) {
-                    WOLFENGINE_ERROR_FUNC("wc_AesGcmEncrypt_ex", rc);
+                    WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER,
+                                          "wc_AesGcmEncrypt_ex", rc);
                     ret = 0;
                 }
             }
@@ -273,7 +277,7 @@ static int we_aes_gcm_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
                                   aes->ivLen, aes->tag, aes->tagLen,
                                   aes->aad, aes->aadLen);
             if (rc != 0) {
-                WOLFENGINE_ERROR_FUNC("wc_AesGcmDecrypt_ex", rc);
+                WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER, "wc_AesGcmDecrypt_ex", rc);
                 ret = 0;
             }
             if (ret == 1) {
@@ -289,7 +293,7 @@ static int we_aes_gcm_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
         ret = (int)len;
     }
 
-    WOLFENGINE_LEAVE("we_aes_gcm_cipher", ret);
+    WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_aes_gcm_cipher", ret);
 
     return ret;
 }
@@ -319,12 +323,13 @@ static int we_aes_gcm_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
     we_AesGcm *aes;
     char errBuff[WOLFENGINE_MAX_ERROR_SZ];
 
-    WOLFENGINE_ENTER("we_aes_gcm_ctrl");
+    WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_aes_gcm_ctrl");
 
     /* Get the AES-GCM data to work with. */
     aes = (we_AesGcm *)EVP_CIPHER_CTX_get_cipher_data(ctx);
     if (aes == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("EVP_CIPHER_CTX_get_cipher_data", aes);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER,
+                                   "EVP_CIPHER_CTX_get_cipher_data", aes);
         ret = 0;
     }
     if (ret == 1) {
@@ -345,7 +350,7 @@ static int we_aes_gcm_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
                 break;
 
             case EVP_CTRL_AEAD_SET_IVLEN:
-                WOLFENGINE_MSG("EVP_CTRL_AEAD_SET_IVLEN");
+                WOLFENGINE_MSG(WE_LOG_CIPHER, "EVP_CTRL_AEAD_SET_IVLEN");
                 /* Set the IV/nonce length to use
                  *   arg [in] length of IV/nonce to use
                  *   ptr [in] Unused
@@ -360,7 +365,7 @@ static int we_aes_gcm_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
                 break;
 
             case EVP_CTRL_GCM_SET_IV_FIXED:
-                WOLFENGINE_MSG("EVP_CTRL_GCM_SET_IV_FIXED");
+                WOLFENGINE_MSG(WE_LOG_CIPHER, "EVP_CTRL_GCM_SET_IV_FIXED");
                 /* Set the fixed part of an IV
                  *   arg [in] size of fixed part of IV/nonce
                  *   ptr [in] fixed part of IV/nonce data
@@ -379,7 +384,8 @@ static int we_aes_gcm_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
                 #ifndef WE_SINGLE_THREADED
                     rc = wc_LockMutex(we_rng_mutex);
                     if (rc != 0) {
-                        WOLFENGINE_ERROR_FUNC("wc_LockMutex", rc);
+                        WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER,
+                                              "wc_LockMutex", rc);
                         ret = 0;
                     }
                     if (ret == 1)
@@ -391,7 +397,8 @@ static int we_aes_gcm_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
                         wc_UnLockMutex(we_rng_mutex);
                 #endif
                         if (rc != 0) {
-                            WOLFENGINE_ERROR_FUNC("wc_AesGcmSetIV", rc);
+                            WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER,
+                                                  "wc_AesGcmSetIV", rc);
                             ret = 0;
                         }
                     }
@@ -405,7 +412,7 @@ static int we_aes_gcm_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
                 break;
 
             case EVP_CTRL_GET_IVLEN:
-                WOLFENGINE_MSG("EVP_CTRL_GET_IVLEN");
+                WOLFENGINE_MSG(WE_LOG_CIPHER, "EVP_CTRL_GET_IVLEN");
                 /* Set the generated IV
                  *   ptr [out] length of iv
                  */
@@ -413,7 +420,7 @@ static int we_aes_gcm_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
                 break;
 
             case EVP_CTRL_GCM_IV_GEN:
-                WOLFENGINE_MSG("EVP_CTRL_GCM_IV_GEN");
+                WOLFENGINE_MSG(WE_LOG_CIPHER, "EVP_CTRL_GCM_IV_GEN");
                 /* Set the generated IV
                  *   arg [in] size of generated IV/nonce
                  *   ptr [in] generated IV/nonce data
@@ -434,7 +441,7 @@ static int we_aes_gcm_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
                 break;
 
             case EVP_CTRL_AEAD_GET_TAG:
-                WOLFENGINE_MSG("EVP_CTRL_AEAD_GET_TAG");
+                WOLFENGINE_MSG(WE_LOG_CIPHER, "EVP_CTRL_AEAD_GET_TAG");
                 /* Get the tag from encryption.
                  *   arg [in] size of buffer
                  *   ptr [in] buffer to copy into
@@ -448,7 +455,7 @@ static int we_aes_gcm_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
                 break;
 
             case EVP_CTRL_AEAD_SET_TAG:
-                WOLFENGINE_MSG("EVP_CTRL_AEAD_SET_TAG");
+                WOLFENGINE_MSG(WE_LOG_CIPHER, "EVP_CTRL_AEAD_SET_TAG");
                 /* Set the tag for decryption.
                  *   arg [in] size of tag
                  *   ptr [in] tag data to copy
@@ -470,7 +477,7 @@ static int we_aes_gcm_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
                 break;
 
             case EVP_CTRL_AEAD_TLS1_AAD:
-                WOLFENGINE_MSG("EVP_CTRL_AEAD_TLS1_AAD");
+                WOLFENGINE_MSG(WE_LOG_CIPHER, "EVP_CTRL_AEAD_TLS1_AAD");
                 /* Set additional authentication data for TLS
                  *   arg [in] size of AAD
                  *   ptr [in] AAD to use
@@ -488,7 +495,8 @@ static int we_aes_gcm_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
                     }
                     aes->aad = OPENSSL_malloc(arg);
                     if (aes->aad == NULL) {
-                        WOLFENGINE_ERROR_FUNC_NULL("OPENSSL_malloc", aes->aad);
+                        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER,
+                                                   "OPENSSL_malloc", aes->aad);
                         ret = 0;
                     }
                     if (ret == 1) {
@@ -530,7 +538,7 @@ static int we_aes_gcm_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
         }
     }
 
-    WOLFENGINE_LEAVE("we_aes_gcm_ctrl", ret);
+    WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_aes_gcm_ctrl", ret);
 
     return ret;
 }
@@ -563,7 +571,7 @@ static int we_init_aesgcm_meth(EVP_CIPHER *cipher)
 {
     int ret;
 
-    WOLFENGINE_ENTER("we_init_aesgcm_meth");
+    WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_init_aesgcm_meth");
 
     ret = EVP_CIPHER_meth_set_iv_length(cipher, GCM_NONCE_MID_SZ);
     if (ret == 1) {
@@ -582,7 +590,7 @@ static int we_init_aesgcm_meth(EVP_CIPHER *cipher)
         ret = EVP_CIPHER_meth_set_impl_ctx_size(cipher, sizeof(we_AesGcm));
     }
 
-    WOLFENGINE_LEAVE("we_init_aesgcm_meth", ret);
+    WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_init_aesgcm_meth", ret);
 
     return ret;
 }
@@ -596,13 +604,14 @@ int we_init_aesgcm_meths()
 {
     int ret = 1;
 
-    WOLFENGINE_ENTER("we_init_aesgcm_meths");
+    WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_init_aesgcm_meths");
 
     /* AES128-GCM */
     we_aes128_gcm_ciph = EVP_CIPHER_meth_new(NID_aes_128_gcm, 1,
                                              AES_128_KEY_SIZE);
     if (we_aes128_gcm_ciph == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("EVP_CIPHER_meth_new - AES-128-GCM",
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER,
+                                   "EVP_CIPHER_meth_new - AES-128-GCM",
                                    we_aes128_gcm_ciph);
         ret = 0;
     }
@@ -615,7 +624,8 @@ int we_init_aesgcm_meths()
         we_aes192_gcm_ciph = EVP_CIPHER_meth_new(NID_aes_192_gcm, 1,
                                                  AES_192_KEY_SIZE);
         if (we_aes192_gcm_ciph == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("EVP_CIPHER_meth_new - AES-192-GCM",
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER,
+                                       "EVP_CIPHER_meth_new - AES-192-GCM",
                                        we_aes192_gcm_ciph);
             ret = 0;
         }
@@ -629,7 +639,8 @@ int we_init_aesgcm_meths()
         we_aes256_gcm_ciph = EVP_CIPHER_meth_new(NID_aes_256_gcm, 1,
                                                  AES_256_KEY_SIZE);
         if (we_aes256_gcm_ciph == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("EVP_CIPHER_meth_new - AES-256-GCM",
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER,
+                                       "EVP_CIPHER_meth_new - AES-256-GCM",
                                        we_aes256_gcm_ciph);
             ret = 0;
         }
@@ -652,7 +663,7 @@ int we_init_aesgcm_meths()
         we_aes256_gcm_ciph = NULL;
     }
 
-    WOLFENGINE_LEAVE("we_init_aesgcm_meths", ret);
+    WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_init_aesgcm_meths", ret);
 
     return ret;
 }

--- a/src/des3_cbc.c
+++ b/src/des3_cbc.c
@@ -61,7 +61,7 @@ static int we_des3_cbc_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
     int rc;
     we_Des3Cbc *des3;
 
-    WOLFENGINE_ENTER("we_des3_cbc_init");
+    WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_des3_cbc_init");
 
     if ((iv == NULL) && (key == NULL)) {
         ret = 0;
@@ -70,7 +70,8 @@ static int we_des3_cbc_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
     if (ret == 1) {
         des3 = (we_Des3Cbc *)EVP_CIPHER_CTX_get_cipher_data(ctx);
         if (des3 == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("EVP_CIPHER_CTX_get_cipher_data", des3);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER,
+                                       "EVP_CIPHER_CTX_get_cipher_data", des3);
             ret = 0;
         }
     }
@@ -78,7 +79,7 @@ static int we_des3_cbc_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
     if ((ret == 1) && (!des3->init)) {
         rc = wc_Des3Init(&des3->des3, NULL, INVALID_DEVID);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_Des3Init", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER, "wc_Des3Init", rc);
             ret = 0;
         }
     }
@@ -94,20 +95,20 @@ static int we_des3_cbc_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
             rc = wc_Des3_SetKey(&des3->des3, key, iv,
                                 enc ? DES_ENCRYPTION : DES_DECRYPTION);
             if (rc != 0) {
-                WOLFENGINE_ERROR_FUNC("wc_Des3_SetKey", rc);
+                WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER, "wc_Des3_SetKey", rc);
                 ret = 0;
             }
         }
         else {
             rc = wc_Des3_SetIV(&des3->des3, iv);
             if (rc != 0) {
-                WOLFENGINE_ERROR_FUNC("wc_Des3_SetIV", rc);
+                WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER, "wc_Des3_SetIV", rc);
                 ret = 0;
             }
         }
     }
 
-    WOLFENGINE_LEAVE("we_des3_cbc_init", ret);
+    WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_des3_cbc_init", ret);
 
     return ret;
 }
@@ -133,13 +134,14 @@ static int we_des3_cbc_encrypt(EVP_CIPHER_CTX *ctx, we_Des3Cbc* des3,
     int outl = 0;
     int noPad = EVP_CIPHER_CTX_test_flags(ctx, EVP_CIPH_NO_PADDING);
 
-    WOLFENGINE_ENTER("we_des3_cbc_encrypt");
+    WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_des3_cbc_encrypt");
 
     /* Length of 0 means Final called. */
     if (len == 0) {
         if (noPad) {
             if (des3->over != 0) {
-                WOLFENGINE_ERROR_MSG("No Pad - last encrypt block not full");
+                WOLFENGINE_ERROR_MSG(WE_LOG_CIPHER,
+                                     "No Pad - last encrypt block not full");
                 ret = 0;
             }
         }
@@ -177,7 +179,8 @@ static int we_des3_cbc_encrypt(EVP_CIPHER_CTX *ctx, we_Des3Cbc* des3,
                 rc = wc_Des3_CbcEncrypt(&des3->des3, out, des3->lastBlock,
                                         DES_BLOCK_SIZE);
                 if (rc != 0) {
-                    WOLFENGINE_ERROR_FUNC("wc_Des3_CbcEncrypt", rc);
+                    WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER,
+                                          "wc_Des3_CbcEncrypt", rc);
                     ret = 0;
                 }
                 /* Data put to output. */
@@ -194,7 +197,8 @@ static int we_des3_cbc_encrypt(EVP_CIPHER_CTX *ctx, we_Des3Cbc* des3,
 
             rc = wc_Des3_CbcEncrypt(&des3->des3, out, in, l);
             if (rc != 0) {
-                WOLFENGINE_ERROR_FUNC("wc_Des3_CbcEncrypt", rc);
+                WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER,
+                                      "wc_Des3_CbcEncrypt", rc);
                 ret = 0;
             }
 
@@ -217,7 +221,7 @@ static int we_des3_cbc_encrypt(EVP_CIPHER_CTX *ctx, we_Des3Cbc* des3,
         ret = -1;
     }
 
-    WOLFENGINE_LEAVE("we_des3_cbc_encrypt", ret);
+    WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_des3_cbc_encrypt", ret);
 
     return ret;
 }
@@ -243,13 +247,14 @@ static int we_des3_cbc_decrypt(EVP_CIPHER_CTX *ctx, we_Des3Cbc* des3,
     int outl = 0;
     int noPad = EVP_CIPHER_CTX_test_flags(ctx, EVP_CIPH_NO_PADDING);
 
-    WOLFENGINE_ENTER("we_des3_cbc_decrypt");
+    WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_des3_cbc_decrypt");
 
     /* Length of 0 means Final called. */
     if (len == 0) {
         if (noPad) {
             if (des3->over != 0) {
-                WOLFENGINE_ERROR_MSG("No Pad - last decrypt block not full");
+                WOLFENGINE_ERROR_MSG(WE_LOG_CIPHER,
+                                     "No Pad - last decrypt block not full");
                 ret = 0;
             }
         }
@@ -259,7 +264,8 @@ static int we_des3_cbc_decrypt(EVP_CIPHER_CTX *ctx, we_Des3Cbc* des3,
 
             /* Must have a full block over to decrypt. */
             if (des3->over != DES_BLOCK_SIZE) {
-                WOLFENGINE_ERROR_MSG("Padding - last cached decrypt block not "
+                WOLFENGINE_ERROR_MSG(WE_LOG_CIPHER,
+                                     "Padding - last cached decrypt block not "
                                      "full");
                 ret = 0;
             }
@@ -268,7 +274,8 @@ static int we_des3_cbc_decrypt(EVP_CIPHER_CTX *ctx, we_Des3Cbc* des3,
                 rc = wc_Des3_CbcDecrypt(&des3->des3, des3->lastBlock,
                                         des3->lastBlock, DES_BLOCK_SIZE);
                 if (rc != 0) {
-                    WOLFENGINE_ERROR_FUNC("wc_Des3_CbcDecrypt", rc);
+                    WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER,
+                                          "wc_Des3_CbcDecrypt", rc);
                     ret = 0;
                 }
                 des3->over = 0;
@@ -277,7 +284,7 @@ static int we_des3_cbc_decrypt(EVP_CIPHER_CTX *ctx, we_Des3Cbc* des3,
                 /* Last byte is length of padding. */
                 pad = des3->lastBlock[DES_BLOCK_SIZE - 1];
                 if ((pad == 0) || (pad > DES_BLOCK_SIZE)) {
-                    WOLFENGINE_ERROR_MSG("Padding byte invalid");
+                    WOLFENGINE_ERROR_MSG(WE_LOG_CIPHER, "Padding byte invalid");
                     ret = 0;
                 }
             }
@@ -288,7 +295,8 @@ static int we_des3_cbc_decrypt(EVP_CIPHER_CTX *ctx, we_Des3Cbc* des3,
                 /* Check padding bytes are all the same. */
                 for (i = outl; (ret == 1) && (i < DES_BLOCK_SIZE - 1); i++) {
                    if (des3->lastBlock[i] != pad) {
-                       WOLFENGINE_ERROR_MSG("Padding byte doesn't different");
+                       WOLFENGINE_ERROR_MSG(WE_LOG_CIPHER,
+                                            "Padding byte doesn't different");
                        ret = 0;
                    }
                 }
@@ -319,7 +327,8 @@ static int we_des3_cbc_decrypt(EVP_CIPHER_CTX *ctx, we_Des3Cbc* des3,
                 rc = wc_Des3_CbcDecrypt(&des3->des3, out, des3->lastBlock,
                                         DES_BLOCK_SIZE);
                 if (rc != 0) {
-                    WOLFENGINE_ERROR_FUNC("wc_Des3_CbcDecrypt", rc);
+                    WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER,
+                                          "wc_Des3_CbcDecrypt", rc);
                     ret = 0;
                 }
                 /* Data put to output. */
@@ -341,7 +350,8 @@ static int we_des3_cbc_decrypt(EVP_CIPHER_CTX *ctx, we_Des3Cbc* des3,
             if (l > 0) {
                 rc = wc_Des3_CbcDecrypt(&des3->des3, out, in, l);
                 if (rc != 0) {
-                    WOLFENGINE_ERROR_FUNC("wc_Des3_CbcDecrypt", rc);
+                    WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER,
+                                          "wc_Des3_CbcDecrypt", rc);
                     ret = 0;
                 }
             }
@@ -365,7 +375,7 @@ static int we_des3_cbc_decrypt(EVP_CIPHER_CTX *ctx, we_Des3Cbc* des3,
         ret = -1;
     }
 
-    WOLFENGINE_LEAVE("we_des3_cbc_decrypt", ret);
+    WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_des3_cbc_decrypt", ret);
 
     return ret;
 }
@@ -388,12 +398,13 @@ static int we_des3_cbc_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
     int ret;
     we_Des3Cbc* des3;
 
-    WOLFENGINE_ENTER("we_des3_cbc_cipher");
+    WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_des3_cbc_cipher");
 
     /* Get the DES3-CBC object to work with. */
     des3 = (we_Des3Cbc *)EVP_CIPHER_CTX_get_cipher_data(ctx);
     if (des3 == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("EVP_CIPHER_CTX_get_cipher_data", des3);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER,
+                                   "EVP_CIPHER_CTX_get_cipher_data", des3);
         ret = -1;
     }
     else if (des3->enc) {
@@ -403,7 +414,7 @@ static int we_des3_cbc_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
         ret = we_des3_cbc_decrypt(ctx, des3, out, in, len);
     }
 
-    WOLFENGINE_LEAVE("we_des3_cbc_cipher", ret);
+    WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_des3_cbc_cipher", ret);
 
     return ret;
 }
@@ -425,7 +436,7 @@ static int we_des3_cbc_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
     we_Des3Cbc *des3;
     char errBuff[WOLFENGINE_MAX_ERROR_SZ];
 
-    WOLFENGINE_ENTER("we_des3_cbc_ctrl");
+    WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_des3_cbc_ctrl");
 
     (void)arg;
     (void)ptr;
@@ -433,7 +444,8 @@ static int we_des3_cbc_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
     /* Get the DES3-CBC data to work with. */
     des3 = (we_Des3Cbc *)EVP_CIPHER_CTX_get_cipher_data(ctx);
     if (des3 != NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("EVP_CIPHER_CTX_get_cipher_data", des3);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER,
+                                   "EVP_CIPHER_CTX_get_cipher_data", des3);
         ret = 0;
     }
     if (ret == 1) {
@@ -441,13 +453,13 @@ static int we_des3_cbc_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
             default:
                 XSNPRINTF(errBuff, sizeof(errBuff), "Unsupported ctrl type %d",
                           type);
-                WOLFENGINE_ERROR_MSG(errBuff);
+                WOLFENGINE_ERROR_MSG(WE_LOG_CIPHER, errBuff);
                 ret = 0;
                 break;
         }
     }
 
-    WOLFENGINE_LEAVE("we_des3_cbc_ctrl", ret);
+    WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_des3_cbc_ctrl", ret);
 
     return ret;
 }
@@ -472,7 +484,7 @@ static int we_init_des3cbc_meth(EVP_CIPHER *cipher)
 {
     int ret;
 
-    WOLFENGINE_ENTER("we_init_des3cbc_meth");
+    WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_init_des3cbc_meth");
 
     ret = EVP_CIPHER_meth_set_iv_length(cipher, DES_IV_SIZE);
     if (ret == 1) {
@@ -491,7 +503,7 @@ static int we_init_des3cbc_meth(EVP_CIPHER *cipher)
         ret = EVP_CIPHER_meth_set_impl_ctx_size(cipher, sizeof(we_Des3Cbc));
     }
 
-    WOLFENGINE_LEAVE("we_init_des3cbc_meth", ret);
+    WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_init_des3cbc_meth", ret);
 
     return ret;
 }
@@ -505,12 +517,12 @@ int we_init_des3cbc_meths()
 {
     int ret = 1;
 
-    WOLFENGINE_ENTER("we_init_des3cbc_meths");
+    WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_init_des3cbc_meths");
 
     /* DES3-CBC */
     we_des3_cbc_ciph = EVP_CIPHER_meth_new(NID_des_ede3_cbc, 1, DES3_KEY_SIZE);
     if (we_des3_cbc_ciph == NULL) {
-        WOLFENGINE_ERROR_MSG("EVP_CIPHER_meth_new - DES3-CBC");
+        WOLFENGINE_ERROR_MSG(WE_LOG_CIPHER, "EVP_CIPHER_meth_new - DES3-CBC");
         ret = 0;
     }
     if (ret == 1) {
@@ -523,7 +535,7 @@ int we_init_des3cbc_meths()
         we_des3_cbc_ciph = NULL;
     }
 
-    WOLFENGINE_LEAVE("we_init_des3cbc_meths", ret);
+    WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_init_des3cbc_meths", ret);
 
     return ret;
 }

--- a/src/dh.c
+++ b/src/dh.c
@@ -50,18 +50,18 @@ static int we_dh_init(DH *dh)
     int rc = 0;
     we_Dh *engineDh = NULL;
 
-    WOLFENGINE_ENTER("we_dh_init");
+    WOLFENGINE_ENTER(WE_LOG_KE, "we_dh_init");
 
     engineDh = (we_Dh *)OPENSSL_zalloc(sizeof(we_Dh));
     if (engineDh == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("OPENSSL_zalloc", engineDh);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_KE, "OPENSSL_zalloc", engineDh);
         ret = 0;
     }
 
     if (ret == 1) {
         rc = wc_InitDhKey(&engineDh->key);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_InitDhKey", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_KE, "wc_InitDhKey", rc);
             ret = 0;
         }
         engineDh->primeLen = DEFAULT_PRIME_LEN;
@@ -70,7 +70,7 @@ static int we_dh_init(DH *dh)
     if (ret == 1) {
         rc = DH_set_ex_data(dh, 0, engineDh);
         if (rc != 1) {
-            WOLFENGINE_ERROR_FUNC("DH_set_ex_data", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_KE, "DH_set_ex_data", rc);
             ret = 0;
         }
     }
@@ -80,7 +80,7 @@ static int we_dh_init(DH *dh)
         OPENSSL_free(engineDh);
     }
 
-    WOLFENGINE_LEAVE("we_dh_init", ret);
+    WOLFENGINE_LEAVE(WE_LOG_KE, "we_dh_init", ret);
 
     return ret;
 }
@@ -96,11 +96,11 @@ static int we_dh_finish(DH *dh)
     int ret = 1;
     we_Dh *engineDh = NULL;
 
-    WOLFENGINE_ENTER("we_dh_finish");
+    WOLFENGINE_ENTER(WE_LOG_KE, "we_dh_finish");
 
     engineDh = (we_Dh *)DH_get_ex_data(dh, 0);
     if (engineDh == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("DH_get_ex_data", engineDh);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_KE, "DH_get_ex_data", engineDh);
         ret = 0;
     }
 
@@ -110,7 +110,7 @@ static int we_dh_finish(DH *dh)
         DH_set_ex_data(dh, 0, NULL);
     }
 
-    WOLFENGINE_LEAVE("we_dh_finish", ret);
+    WOLFENGINE_LEAVE(WE_LOG_KE, "we_dh_finish", ret);
 
     return ret;
 }
@@ -132,18 +132,18 @@ static int we_set_dh_parameters(const DH *dh, we_Dh *engineDh)
     unsigned char *gBuf = NULL;
     int gBufLen = 0;
 
-    WOLFENGINE_ENTER("we_set_dh_parameters");
+    WOLFENGINE_ENTER(WE_LOG_KE, "we_set_dh_parameters");
 
     pBuf = (unsigned char *)OPENSSL_malloc(BN_num_bytes(DH_get0_p(dh)));
     if (pBuf == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("OPENSSL_malloc", pBuf);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_KE, "OPENSSL_malloc", pBuf);
         ret = 0;
     }
 
     if (ret == 1) {
         gBuf = (unsigned char *)OPENSSL_malloc(BN_num_bytes(DH_get0_g(dh)));
         if (gBuf == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("OPENSSL_malloc", gBuf);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_KE, "OPENSSL_malloc", gBuf);
             ret = 0;
         }
     }
@@ -151,7 +151,7 @@ static int we_set_dh_parameters(const DH *dh, we_Dh *engineDh)
     if (ret == 1) {
         pBufLen = BN_bn2bin(DH_get0_p(dh), pBuf);
         if (pBufLen == 0) {
-            WOLFENGINE_ERROR_FUNC("BN_bn2bin", pBufLen);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_KE, "BN_bn2bin", pBufLen);
             ret = 0;
         }
     }
@@ -159,7 +159,7 @@ static int we_set_dh_parameters(const DH *dh, we_Dh *engineDh)
     if (ret == 1) {
         gBufLen = BN_bn2bin(DH_get0_g(dh), gBuf);
         if (gBufLen == 0) {
-            WOLFENGINE_ERROR_FUNC("BN_bn2bin", gBufLen);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_KE, "BN_bn2bin", gBufLen);
             ret = 0;
         }
     }
@@ -167,7 +167,7 @@ static int we_set_dh_parameters(const DH *dh, we_Dh *engineDh)
     if (ret == 1) {
         rc = wc_DhSetKey(&engineDh->key, pBuf, pBufLen, gBuf, gBufLen);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_DhSetKey", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_KE, "wc_DhSetKey", rc);
             ret = 0;
         }
     }
@@ -177,7 +177,7 @@ static int we_set_dh_parameters(const DH *dh, we_Dh *engineDh)
     if (gBuf != NULL)
         OPENSSL_free(gBuf);
 
-    WOLFENGINE_LEAVE("we_set_dh_parameters", ret);
+    WOLFENGINE_LEAVE(WE_LOG_KE, "we_set_dh_parameters", ret);
 
     return ret;
 }
@@ -204,12 +204,12 @@ static int we_dh_generate_key_int(DH *dh, we_Dh *engineDh)
     BIGNUM *privBn = NULL;
     BIGNUM *pubBn = NULL;
 
-    WOLFENGINE_ENTER("we_dh_generate_key_int");
+    WOLFENGINE_ENTER(WE_LOG_KE, "we_dh_generate_key_int");
 
     pubLen = BN_num_bytes(DH_get0_p(dh));
     pub = (unsigned char*)OPENSSL_malloc(pubLen);
     if (pub == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("OPENSSL_malloc", pub);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_KE, "OPENSSL_malloc", pub);
         ret = 0;
     }
 
@@ -224,7 +224,7 @@ static int we_dh_generate_key_int(DH *dh, we_Dh *engineDh)
 
         priv = (unsigned char*)OPENSSL_malloc(privLen);
         if (priv == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("OPENSSL_malloc", priv);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_KE, "OPENSSL_malloc", priv);
             ret = 0;
         }
     }
@@ -233,7 +233,7 @@ static int we_dh_generate_key_int(DH *dh, we_Dh *engineDh)
     if (ret == 1) {
         rc = we_set_dh_parameters(dh, engineDh);
         if (rc != 1) {
-            WOLFENGINE_ERROR_FUNC("we_set_dh_parameters", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_KE, "we_set_dh_parameters", rc);
             ret = 0;
         }
     }
@@ -244,7 +244,7 @@ static int we_dh_generate_key_int(DH *dh, we_Dh *engineDh)
         rc = wc_DhGenerateKeyPair(&engineDh->key, we_rng, priv, &actualPrivLen,
                                   pub, &actualPubLen);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_DhGenerateKeyPair", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_KE, "wc_DhGenerateKeyPair", rc);
             ret = 0;
         }
     }
@@ -252,7 +252,7 @@ static int we_dh_generate_key_int(DH *dh, we_Dh *engineDh)
     if (ret == 1) {
         privBn = BN_bin2bn(priv, actualPrivLen, NULL);
         if (privBn == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("BN_bin2bn", privBn);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_KE, "BN_bin2bn", privBn);
             ret = 0;
         }
     }
@@ -260,7 +260,7 @@ static int we_dh_generate_key_int(DH *dh, we_Dh *engineDh)
     if (ret == 1) {
         pubBn = BN_bin2bn(pub, actualPubLen, NULL);
         if (pubBn == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("BN_bin2bn", pubBn);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_KE, "BN_bin2bn", pubBn);
             ret = 0;
         }
     }
@@ -268,7 +268,7 @@ static int we_dh_generate_key_int(DH *dh, we_Dh *engineDh)
     if (ret == 1) {
         rc = DH_set0_key(dh, pubBn, privBn);
         if (rc != 1) {
-            WOLFENGINE_ERROR_FUNC("DH_set0_key", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_KE, "DH_set0_key", rc);
             BN_free(privBn);
             ret = 0;
         }
@@ -279,7 +279,7 @@ static int we_dh_generate_key_int(DH *dh, we_Dh *engineDh)
     if (priv != NULL)
         OPENSSL_clear_free(priv, privLen);
 
-    WOLFENGINE_LEAVE("we_dh_generate_key_int", ret);
+    WOLFENGINE_LEAVE(WE_LOG_KE, "we_dh_generate_key_int", ret);
 
     return ret;
 }
@@ -297,23 +297,23 @@ static int we_dh_generate_key(DH *dh)
     int rc = 0;
     we_Dh *engineDh = NULL;
 
-    WOLFENGINE_ENTER("we_dh_generate_key");
+    WOLFENGINE_ENTER(WE_LOG_KE, "we_dh_generate_key");
 
     engineDh = (we_Dh *)DH_get_ex_data(dh, 0);
     if (engineDh == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("DH_get_ex_data", engineDh);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_KE, "DH_get_ex_data", engineDh);
         ret = 0;
     }
 
     if (ret == 1) {
         rc = we_dh_generate_key_int(dh, engineDh);
         if (rc != 1) {
-            WOLFENGINE_ERROR_FUNC("we_dh_generate_key_int", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_KE, "we_dh_generate_key_int", rc);
             ret = 0;
         }
     }
 
-    WOLFENGINE_LEAVE("we_dh_generate_key", ret);
+    WOLFENGINE_LEAVE(WE_LOG_KE, "we_dh_generate_key", ret);
 
     return ret;
 }
@@ -341,12 +341,12 @@ static int we_dh_compute_key_int(we_Dh *engineDh, unsigned char *secret,
     int privLen = 0;
     unsigned int secLen = 0;
 
-    WOLFENGINE_ENTER("we_dh_compute_key_int");
+    WOLFENGINE_ENTER(WE_LOG_KE, "we_dh_compute_key_int");
 
     if (ret == 1) {
         pubBuf = (unsigned char *)OPENSSL_malloc(BN_num_bytes(pubKey));
         if (pubBuf == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("OPENSSL_malloc", pubBuf);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_KE, "OPENSSL_malloc", pubBuf);
             ret = 0;
         }
     }
@@ -355,7 +355,7 @@ static int we_dh_compute_key_int(we_Dh *engineDh, unsigned char *secret,
         privBuf = (unsigned char *)OPENSSL_malloc(BN_num_bytes(
                                                   DH_get0_priv_key(dh)));
         if (privBuf == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("OPENSSL_malloc", privBuf);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_KE, "OPENSSL_malloc", privBuf);
             ret = 0;
         }
     }
@@ -363,7 +363,7 @@ static int we_dh_compute_key_int(we_Dh *engineDh, unsigned char *secret,
     if (ret == 1) {
         pubLen = BN_bn2bin(pubKey, pubBuf);
         if (pubLen == 0) {
-            WOLFENGINE_ERROR_FUNC("BN_bn2bin", pubLen);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_KE, "BN_bn2bin", pubLen);
             ret = 0;
         }
     }
@@ -371,7 +371,7 @@ static int we_dh_compute_key_int(we_Dh *engineDh, unsigned char *secret,
     if (ret == 1) {
         privLen = BN_bn2bin(DH_get0_priv_key(dh), privBuf);
         if (privLen == 0) {
-            WOLFENGINE_ERROR_FUNC("BN_bn2bin", privLen);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_KE, "BN_bn2bin", privLen);
             ret = 0;
         }
     }
@@ -380,7 +380,7 @@ static int we_dh_compute_key_int(we_Dh *engineDh, unsigned char *secret,
     if (ret == 1) {
         rc = we_set_dh_parameters(dh, engineDh);
         if (rc != 1) {
-            WOLFENGINE_ERROR_FUNC("we_set_dh_parameters", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_KE, "we_set_dh_parameters", rc);
             ret = 0;
         }
     }
@@ -390,7 +390,7 @@ static int we_dh_compute_key_int(we_Dh *engineDh, unsigned char *secret,
         rc = wc_DhAgree(&engineDh->key, secret, &secLen, privBuf, privLen,
                          pubBuf, pubLen);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_DhAgree", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_KE, "wc_DhAgree", rc);
             ret = 0;
         }
         else {
@@ -403,7 +403,7 @@ static int we_dh_compute_key_int(we_Dh *engineDh, unsigned char *secret,
     if (privBuf != NULL)
         OPENSSL_free(privBuf);
 
-    WOLFENGINE_LEAVE("we_dh_compute_key_int", ret);
+    WOLFENGINE_LEAVE(WE_LOG_KE, "we_dh_compute_key_int", ret);
 
     return ret;
 }
@@ -424,11 +424,11 @@ static int we_dh_compute_key(unsigned char *secret, const BIGNUM *pubKey,
     we_Dh *engineDh = NULL;
     size_t secretLen = 0;
 
-    WOLFENGINE_ENTER("we_compute_key");
+    WOLFENGINE_ENTER(WE_LOG_KE, "we_compute_key");
 
     engineDh = (we_Dh *)DH_get_ex_data(dh, 0);
     if (engineDh == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("DH_get_ex_data", engineDh);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_KE, "DH_get_ex_data", engineDh);
         ret = -1;
     }
 
@@ -436,7 +436,7 @@ static int we_dh_compute_key(unsigned char *secret, const BIGNUM *pubKey,
         secretLen = DH_size(dh);
         ret = we_dh_compute_key_int(engineDh, secret, &secretLen, pubKey, dh);
         if (ret == 0) {
-            WOLFENGINE_ERROR_FUNC("we_dh_compute_key_int", ret);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_KE, "we_dh_compute_key_int", ret);
             ret = -1;
         }
         else {
@@ -444,7 +444,7 @@ static int we_dh_compute_key(unsigned char *secret, const BIGNUM *pubKey,
         }
     }
 
-    WOLFENGINE_LEAVE("we_compute_key", ret);
+    WOLFENGINE_LEAVE(WE_LOG_KE, "we_compute_key", ret);
     (void)ret;
 
     return ret;
@@ -459,11 +459,11 @@ int we_init_dh_meth(void)
 {
     int ret = 1;
 
-    WOLFENGINE_ENTER("we_init_dh_meth");
+    WOLFENGINE_ENTER(WE_LOG_KE, "we_init_dh_meth");
 
     we_dh_method = DH_meth_new("wolfengine_dh", 0);
     if (we_dh_method == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("DH_meth_new", we_dh_method);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_KE, "DH_meth_new", we_dh_method);
         ret = 0;
     }
 
@@ -479,7 +479,7 @@ int we_init_dh_meth(void)
         we_dh_method = NULL;
     }
 
-    WOLFENGINE_LEAVE("we_init_dh_meth", ret);
+    WOLFENGINE_LEAVE(WE_LOG_KE, "we_init_dh_meth", ret);
 
     return ret;
 }
@@ -501,18 +501,18 @@ static int we_dh_pkey_init(EVP_PKEY_CTX *ctx)
     int rc = 0;
     we_Dh *dh;
 
-    WOLFENGINE_ENTER("we_dh_pkey_init");
+    WOLFENGINE_ENTER(WE_LOG_KE, "we_dh_pkey_init");
 
     dh = (we_Dh *)OPENSSL_zalloc(sizeof(we_Dh));
     if (dh == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("OPENSSL_zalloc", dh);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_KE, "OPENSSL_zalloc", dh);
         ret = 0;
     }
 
     if (ret == 1) {
         rc = wc_InitDhKey(&dh->key);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_InitDhKey", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_KE, "wc_InitDhKey", rc);
             ret = 0;
         }
         dh->primeLen = DEFAULT_PRIME_LEN;
@@ -527,7 +527,7 @@ static int we_dh_pkey_init(EVP_PKEY_CTX *ctx)
         OPENSSL_free(dh);
     }
 
-    WOLFENGINE_LEAVE("we_dh_pkey_init", ret);
+    WOLFENGINE_LEAVE(WE_LOG_KE, "we_dh_pkey_init", ret);
 
     return ret;
 }
@@ -541,7 +541,7 @@ static void we_dh_pkey_cleanup(EVP_PKEY_CTX *ctx)
 {
     we_Dh *dh = (we_Dh *)EVP_PKEY_CTX_get_data(ctx);
 
-    WOLFENGINE_ENTER("we_dh_pkey_cleanup");
+    WOLFENGINE_ENTER(WE_LOG_KE, "we_dh_pkey_cleanup");
 
     if (dh != NULL) {
         wc_FreeDhKey(&dh->key);
@@ -549,7 +549,7 @@ static void we_dh_pkey_cleanup(EVP_PKEY_CTX *ctx)
         EVP_PKEY_CTX_set_data(ctx, NULL);
     }
 
-    WOLFENGINE_LEAVE("we_dh_pkey_cleanup", 1);
+    WOLFENGINE_LEAVE(WE_LOG_KE, "we_dh_pkey_cleanup", 1);
 }
 
 /**
@@ -576,11 +576,11 @@ static int we_dh_pkey_ctrl(EVP_PKEY_CTX *ctx, int type, int num, void *ptr)
 
     (void)ptr;
 
-    WOLFENGINE_ENTER("we_dh_pkey_ctrl");
+    WOLFENGINE_ENTER(WE_LOG_KE, "we_dh_pkey_ctrl");
 
     dh = (we_Dh *)EVP_PKEY_CTX_get_data(ctx);
     if (dh == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("EVP_PKEY_CTX_get_data", dh);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_KE, "EVP_PKEY_CTX_get_data", dh);
         ret = 0;
     }
 
@@ -589,7 +589,8 @@ static int we_dh_pkey_ctrl(EVP_PKEY_CTX *ctx, int type, int num, void *ptr)
             case EVP_PKEY_CTRL_DH_PARAMGEN_PRIME_LEN:
                 /* These are the sizes allowed by wolfCrypt. */
                 if (num != 1024 && num != 2048 && num != 3072) {
-                    WOLFENGINE_ERROR_MSG("Invalid DH prime bit length.");
+                    WOLFENGINE_ERROR_MSG(WE_LOG_KE,
+                                         "Invalid DH prime bit length.");
                     ret = 0;
                 }
                 else {
@@ -608,13 +609,13 @@ static int we_dh_pkey_ctrl(EVP_PKEY_CTX *ctx, int type, int num, void *ptr)
             default:
                 XSNPRINTF(errBuff, sizeof(errBuff), "Unsupported ctrl type %d",
                           type);
-                WOLFENGINE_ERROR_MSG(errBuff);
+                WOLFENGINE_ERROR_MSG(WE_LOG_KE, errBuff);
                 ret = 0;
                 break;
         }
     }
 
-    WOLFENGINE_LEAVE("we_dh_pkey_ctrl", ret);
+    WOLFENGINE_LEAVE(WE_LOG_KE, "we_dh_pkey_ctrl", ret);
 
     return ret;
 }
@@ -640,33 +641,33 @@ static int we_convert_dh_params(DhKey *wolfDh, DH *osslDh)
     unsigned char *q = NULL;
     unsigned int qLen = 0;
 
-    WOLFENGINE_ENTER("we_convert_dh_params");
+    WOLFENGINE_ENTER(WE_LOG_KE, "we_convert_dh_params");
 
     /* Call with NULL for the buffers to get required lengths. */
     rc = wc_DhExportParamsRaw(wolfDh, NULL, &pLen, NULL, &qLen, NULL, &gLen);
     if (rc != LENGTH_ONLY_E) {
-        WOLFENGINE_ERROR_FUNC("wc_DhExportParamsRaw", rc);
+        WOLFENGINE_ERROR_FUNC(WE_LOG_KE, "wc_DhExportParamsRaw", rc);
         ret = 0;
     }
 
     if (ret == 1) {
         p = (unsigned char*)OPENSSL_malloc(pLen);
         if (p == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("OPENSSL_malloc", p);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_KE, "OPENSSL_malloc", p);
             ret = 0;
         }
     }
     if (ret == 1) {
         q = (unsigned char*)OPENSSL_malloc(qLen);
         if (q == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("OPENSSL_malloc", q);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_KE, "OPENSSL_malloc", q);
             ret = 0;
         }
     }
     if (ret == 1) {
         g = (unsigned char*)OPENSSL_malloc(pLen);
         if (g == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("OPENSSL_malloc", g);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_KE, "OPENSSL_malloc", g);
             ret = 0;
         }
     }
@@ -674,7 +675,7 @@ static int we_convert_dh_params(DhKey *wolfDh, DH *osslDh)
         /* With buffers allocated, write the parameters. */
         rc = wc_DhExportParamsRaw(wolfDh, p, &pLen, q, &qLen, g, &gLen);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_DhExportParamsRaw", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_KE, "wc_DhExportParamsRaw", rc);
             ret = 0;
         }
     }
@@ -683,28 +684,28 @@ static int we_convert_dh_params(DhKey *wolfDh, DH *osslDh)
     if (ret == 1) {
         pBn = BN_bin2bn(p, pLen, NULL);
         if (pBn == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("BN_bin2bn", pBn);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_KE, "BN_bin2bn", pBn);
             ret = 0;
         }
     }
     if (ret == 1) {
         qBn = BN_bin2bn(q, qLen, NULL);
         if (qBn == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("BN_bin2bn", qBn);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_KE, "BN_bin2bn", qBn);
             ret = 0;
         }
     }
     if (ret == 1) {
         gBn = BN_bin2bn(g, gLen, NULL);
         if (gBn == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("BN_bin2bn", gBn);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_KE, "BN_bin2bn", gBn);
             ret = 0;
         }
     }
     if (ret == 1) {
         rc = DH_set0_pqg(osslDh, pBn, qBn, gBn);
         if (rc != 1) {
-            WOLFENGINE_ERROR_FUNC("DH_set0_pqg", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_KE, "DH_set0_pqg", rc);
             ret = 0;
         }
     }
@@ -719,7 +720,7 @@ static int we_convert_dh_params(DhKey *wolfDh, DH *osslDh)
         OPENSSL_free(g);
     }
 
-    WOLFENGINE_LEAVE("we_convert_dh_params", ret);
+    WOLFENGINE_LEAVE(WE_LOG_KE, "we_convert_dh_params", ret);
 
     return ret;
 }
@@ -738,18 +739,19 @@ static int we_dh_pkey_paramgen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
     we_Dh *engineDh = NULL;
     DH *dh = NULL;
 
-    WOLFENGINE_ENTER("we_dh_pkey_paramgen");
+    WOLFENGINE_ENTER(WE_LOG_KE, "we_dh_pkey_paramgen");
     
     engineDh = (we_Dh *)EVP_PKEY_CTX_get_data(ctx);
     if (engineDh == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("EVP_PKEY_CTX_get_data", engineDh);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_KE,
+                                   "EVP_PKEY_CTX_get_data", engineDh);
         ret = 0;
     }
 
     if (ret == 1) {
         dh = DH_new();
         if (dh == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("DH_new", dh);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_KE, "DH_new", dh);
             ret = 0;
         }
     }
@@ -758,7 +760,7 @@ static int we_dh_pkey_paramgen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
     if (ret == 1) {
         rc = wc_DhGenerateParams(we_rng, engineDh->primeLen, &engineDh->key);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("we_dh_pkey_paramgen", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_KE, "we_dh_pkey_paramgen", rc);
             ret = 0;
         }
     }
@@ -767,7 +769,7 @@ static int we_dh_pkey_paramgen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
     if (ret == 1) {
         rc = we_convert_dh_params(&engineDh->key, dh);
         if (rc != 1) {
-            WOLFENGINE_ERROR_FUNC("we_convert_dh_params", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_KE, "we_convert_dh_params", rc);
             ret = 0;
         }
     }
@@ -776,7 +778,7 @@ static int we_dh_pkey_paramgen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
         EVP_PKEY_assign_DH(pkey, dh);
     }
 
-    WOLFENGINE_LEAVE("we_dh_pkey_paramgen", ret);
+    WOLFENGINE_LEAVE(WE_LOG_KE, "we_dh_pkey_paramgen", ret);
 
     return ret;
 }
@@ -797,11 +799,12 @@ static int we_dh_pkey_keygen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
     EVP_PKEY *paramsKey;
     DH *dh;
 
-    WOLFENGINE_ENTER("we_dh_pkey_keygen");
+    WOLFENGINE_ENTER(WE_LOG_KE, "we_dh_pkey_keygen");
     
     engineDh = (we_Dh *)EVP_PKEY_CTX_get_data(ctx);
     if (engineDh == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("EVP_PKEY_CTX_get_data", engineDh);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_KE,
+                                   "EVP_PKEY_CTX_get_data", engineDh);
         ret = 0;
     }
 
@@ -809,7 +812,7 @@ static int we_dh_pkey_keygen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
     if (ret == 1) {
         dh = DH_new();
         if (dh == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("DH_new", dh);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_KE, "DH_new", dh);
             ret = 0;
         }
     }
@@ -818,7 +821,7 @@ static int we_dh_pkey_keygen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
     if (ret == 1) {
         ret = EVP_PKEY_assign_DH(pkey, dh);
         if (ret != 1) {
-            WOLFENGINE_ERROR_FUNC("EVP_PKEY_assign_DH", ret);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_KE, "EVP_PKEY_assign_DH", ret);
         }
     }
     
@@ -826,7 +829,8 @@ static int we_dh_pkey_keygen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
     if (ret == 1) {
         paramsKey = EVP_PKEY_CTX_get0_pkey(ctx);
         if (paramsKey == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("EVP_PKEY_CTX_get0_pkey", paramsKey);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_KE,
+                                       "EVP_PKEY_CTX_get0_pkey", paramsKey);
             ret = 0;
         }
     }
@@ -835,7 +839,7 @@ static int we_dh_pkey_keygen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
     if (ret == 1) {
         rc = EVP_PKEY_copy_parameters(pkey, paramsKey);
         if (rc != 1) {
-            WOLFENGINE_ERROR_FUNC("EVP_PKEY_copy_parameters", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_KE, "EVP_PKEY_copy_parameters", rc);
             ret = 0;
         }
     }
@@ -844,12 +848,12 @@ static int we_dh_pkey_keygen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
     if (ret == 1) {
         rc = we_dh_generate_key_int(dh, engineDh);
         if (rc != 1) {
-            WOLFENGINE_ERROR_FUNC("we_dh_generate_key_int", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_KE, "we_dh_generate_key_int", rc);
             ret = 0;
         }
     }
 
-    WOLFENGINE_LEAVE("we_dh_generate_key", ret);
+    WOLFENGINE_LEAVE(WE_LOG_KE, "we_dh_generate_key", ret);
 
     return ret;
 }
@@ -874,18 +878,20 @@ static int we_dh_pkey_derive(EVP_PKEY_CTX *ctx, unsigned char *secret,
     DH *peerDh = NULL;
     const BIGNUM *peerPub = NULL;
 
-    WOLFENGINE_ENTER("we_dh_pkey_derive");
+    WOLFENGINE_ENTER(WE_LOG_KE, "we_dh_pkey_derive");
     
     engineDh = (we_Dh *)EVP_PKEY_CTX_get_data(ctx);
     if (engineDh == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("EVP_PKEY_CTX_get_data", engineDh);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_KE,
+                                   "EVP_PKEY_CTX_get_data", engineDh);
         ret = 0;
     }
 
     if (ret == 1) {
         ourKey = EVP_PKEY_CTX_get0_pkey(ctx);
         if (ourKey == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("EVP_PKEY_CTX_get0_pkey", ourKey);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_KE,
+                                       "EVP_PKEY_CTX_get0_pkey", ourKey);
             ret = 0;
         }
     }
@@ -893,7 +899,7 @@ static int we_dh_pkey_derive(EVP_PKEY_CTX *ctx, unsigned char *secret,
     if (ret == 1) {
         ourDh = EVP_PKEY_get0_DH(ourKey);
         if (ourDh == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("EVP_PKEY_get0_DH", ourDh);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_KE, "EVP_PKEY_get0_DH", ourDh);
             ret = 0;
         }
     }
@@ -906,7 +912,8 @@ static int we_dh_pkey_derive(EVP_PKEY_CTX *ctx, unsigned char *secret,
     if (ret == 1) {
         peerKey = EVP_PKEY_CTX_get0_peerkey(ctx);
         if (peerKey == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("EVP_PKEY_CTX_get0_peerkey", peerKey);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_KE,
+                                       "EVP_PKEY_CTX_get0_peerkey", peerKey);
             ret = 0;
         }
     }
@@ -914,7 +921,7 @@ static int we_dh_pkey_derive(EVP_PKEY_CTX *ctx, unsigned char *secret,
     if (ret == 1) {
         peerDh = EVP_PKEY_get0_DH(peerKey);
         if (peerDh == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("EVP_PKEY_get0_DH", peerDh);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_KE, "EVP_PKEY_get0_DH", peerDh);
             ret = 0;
         }
     }
@@ -922,7 +929,7 @@ static int we_dh_pkey_derive(EVP_PKEY_CTX *ctx, unsigned char *secret,
     if (ret == 1) {
         peerPub = DH_get0_pub_key(peerDh);
         if (peerPub == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("DH_get0_pub_key", NULL);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_KE, "DH_get0_pub_key", NULL);
             ret = 0;
         }
     }
@@ -931,11 +938,11 @@ static int we_dh_pkey_derive(EVP_PKEY_CTX *ctx, unsigned char *secret,
         ret = we_dh_compute_key_int(engineDh, secret, secretLen, peerPub,
                                     ourDh);
         if (ret != 1) {
-            WOLFENGINE_ERROR_FUNC("we_dh_compute_key_int", ret);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_KE, "we_dh_compute_key_int", ret);
         }
     }
 
-    WOLFENGINE_LEAVE("we_dh_pkey_derive", ret);
+    WOLFENGINE_LEAVE(WE_LOG_KE, "we_dh_pkey_derive", ret);
 
     return ret;
 }
@@ -949,11 +956,12 @@ int we_init_dh_pkey_meth(void)
 {
     int ret = 1;
 
-    WOLFENGINE_ENTER("we_init_dh_pkey_meth");
+    WOLFENGINE_ENTER(WE_LOG_KE, "we_init_dh_pkey_meth");
 
     we_dh_pkey_method = EVP_PKEY_meth_new(EVP_PKEY_DH, 0);
     if (we_dh_pkey_method == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("EVP_PKEY_meth_new", we_dh_pkey_method);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_KE,
+                                   "EVP_PKEY_meth_new", we_dh_pkey_method);
         ret = 0;
     }
 
@@ -972,7 +980,7 @@ int we_init_dh_pkey_meth(void)
         we_dh_pkey_method = NULL;
     }
 
-    WOLFENGINE_LEAVE("we_init_dh_pkey_meth", ret);
+    WOLFENGINE_LEAVE(WE_LOG_KE, "we_init_dh_pkey_meth", ret);
 
     return ret;
 }

--- a/src/digest.c
+++ b/src/digest.c
@@ -37,15 +37,15 @@ static int we_sha_init(EVP_MD_CTX *ctx)
 {
     int ret = 1, rc;
 
-    WOLFENGINE_ENTER("we_sha_init");
+    WOLFENGINE_ENTER(WE_LOG_DIGEST, "we_sha_init");
 
     rc = wc_InitSha((wc_Sha*)EVP_MD_CTX_md_data(ctx));
     if (rc != 0) {
-        WOLFENGINE_ERROR_FUNC("wc_InitSha", rc);
+        WOLFENGINE_ERROR_FUNC(WE_LOG_DIGEST, "wc_InitSha", rc);
         ret = 0;
     }
 
-    WOLFENGINE_LEAVE("we_sha_init", ret);
+    WOLFENGINE_LEAVE(WE_LOG_DIGEST, "we_sha_init", ret);
 
     return ret;
 }
@@ -62,16 +62,16 @@ static int we_sha_update(EVP_MD_CTX *ctx, const void *data, size_t len)
 {
     int ret = 1, rc;
 
-    WOLFENGINE_ENTER("we_sha_update");
+    WOLFENGINE_ENTER(WE_LOG_DIGEST, "we_sha_update");
 
     rc = wc_ShaUpdate((wc_Sha*)EVP_MD_CTX_md_data(ctx),
                          (const byte*)data, (word32)len);
     if (rc != 0) {
-        WOLFENGINE_ERROR_FUNC("wc_ShaUpdate", rc);
+        WOLFENGINE_ERROR_FUNC(WE_LOG_DIGEST, "wc_ShaUpdate", rc);
         ret = 0;
     }
 
-    WOLFENGINE_LEAVE("we_sha_update", ret);
+    WOLFENGINE_LEAVE(WE_LOG_DIGEST, "we_sha_update", ret);
 
     return ret;
 }
@@ -87,18 +87,18 @@ static int we_sha_final(EVP_MD_CTX *ctx, unsigned char *md)
 {
     int ret = 1, rc;
 
-    WOLFENGINE_ENTER("we_sha_final");
+    WOLFENGINE_ENTER(WE_LOG_DIGEST, "we_sha_final");
 
     rc = wc_ShaFinal((wc_Sha*)EVP_MD_CTX_md_data(ctx), (byte*)md);
     if (rc != 0) {
-        WOLFENGINE_ERROR_FUNC("wc_ShaFinal", rc);
+        WOLFENGINE_ERROR_FUNC(WE_LOG_DIGEST, "wc_ShaFinal", rc);
         ret = 0;
     } else {
-        WOLFENGINE_MSG("SHA-1 Digest");
-        WOLFENGINE_BUFFER(md, WC_SHA_DIGEST_SIZE);
+        WOLFENGINE_MSG(WE_LOG_DIGEST, "SHA-1 Digest");
+        WOLFENGINE_BUFFER(WE_LOG_DIGEST, md, WC_SHA_DIGEST_SIZE);
     }
 
-    WOLFENGINE_LEAVE("we_sha_final", ret);
+    WOLFENGINE_LEAVE(WE_LOG_DIGEST, "we_sha_final", ret);
 
     return ret;
 }
@@ -111,11 +111,11 @@ static int we_sha_final(EVP_MD_CTX *ctx, unsigned char *md)
  */
 static int we_sha_cleanup(EVP_MD_CTX *ctx)
 {
-    WOLFENGINE_ENTER("we_sha_cleanup");
+    WOLFENGINE_ENTER(WE_LOG_DIGEST, "we_sha_cleanup");
 
     wc_ShaFree((wc_Sha*)EVP_MD_CTX_md_data(ctx));
 
-    WOLFENGINE_LEAVE("we_sha_cleanup", 1);
+    WOLFENGINE_LEAVE(WE_LOG_DIGEST, "we_sha_cleanup", 1);
     return 1;
 }
 
@@ -131,7 +131,7 @@ int we_init_sha_meth()
 {
     int ret;
 
-    WOLFENGINE_ENTER("we_init_sha_meth");
+    WOLFENGINE_ENTER(WE_LOG_DIGEST, "we_init_sha_meth");
 
     ret = (we_sha1_md = EVP_MD_meth_new(NID_sha, EVP_PKEY_NONE)) != NULL;
     if (ret == 1) {
@@ -157,7 +157,7 @@ int we_init_sha_meth()
         EVP_MD_meth_free(we_sha1_md);
     }
 
-    WOLFENGINE_LEAVE("we_init_sha_meth", ret);
+    WOLFENGINE_LEAVE(WE_LOG_DIGEST, "we_init_sha_meth", ret);
 
     return ret;
 };
@@ -180,15 +180,15 @@ static int we_sha224_init(EVP_MD_CTX *ctx)
 {
     int ret = 1, rc;
 
-    WOLFENGINE_ENTER("we_sha224_init");
+    WOLFENGINE_ENTER(WE_LOG_DIGEST, "we_sha224_init");
 
     rc = wc_InitSha224((wc_Sha224*)EVP_MD_CTX_md_data(ctx));
     if (rc != 0) {
-        WOLFENGINE_ERROR_FUNC("wc_InitSha224", rc);
+        WOLFENGINE_ERROR_FUNC(WE_LOG_DIGEST, "wc_InitSha224", rc);
         ret = 0;
     }
 
-    WOLFENGINE_LEAVE("we_sha224_init", ret);
+    WOLFENGINE_LEAVE(WE_LOG_DIGEST, "we_sha224_init", ret);
 
     return ret;
 }
@@ -205,16 +205,16 @@ static int we_sha224_update(EVP_MD_CTX *ctx, const void *data, size_t len)
 {
     int ret = 1, rc;
 
-    WOLFENGINE_ENTER("we_sha224_update");
+    WOLFENGINE_ENTER(WE_LOG_DIGEST, "we_sha224_update");
 
     rc = wc_Sha224Update((wc_Sha224*)EVP_MD_CTX_md_data(ctx),
                          (const byte*)data, (word32)len);
     if (rc != 0) {
-        WOLFENGINE_ERROR_FUNC("wc_Sha224Update", rc);
+        WOLFENGINE_ERROR_FUNC(WE_LOG_DIGEST, "wc_Sha224Update", rc);
         ret = 0;
     }
 
-    WOLFENGINE_LEAVE("we_sha224_update", ret);
+    WOLFENGINE_LEAVE(WE_LOG_DIGEST, "we_sha224_update", ret);
 
     return ret;
 }
@@ -230,18 +230,18 @@ static int we_sha224_final(EVP_MD_CTX *ctx, unsigned char *md)
 {
     int ret = 1, rc;
 
-    WOLFENGINE_ENTER("we_sha224_final");
+    WOLFENGINE_ENTER(WE_LOG_DIGEST, "we_sha224_final");
 
     rc = wc_Sha224Final((wc_Sha224*)EVP_MD_CTX_md_data(ctx), (byte*)md);
     if (rc != 0) {
-        WOLFENGINE_ERROR_FUNC("wc_Sha224Final", rc);
+        WOLFENGINE_ERROR_FUNC(WE_LOG_DIGEST, "wc_Sha224Final", rc);
         ret = 0;
     } else {
-        WOLFENGINE_MSG("SHA-224 Digest");
-        WOLFENGINE_BUFFER(md, WC_SHA224_DIGEST_SIZE);
+        WOLFENGINE_MSG(WE_LOG_DIGEST, "SHA-224 Digest");
+        WOLFENGINE_BUFFER(WE_LOG_DIGEST, md, WC_SHA224_DIGEST_SIZE);
     }
 
-    WOLFENGINE_LEAVE("we_sha224_final", ret);
+    WOLFENGINE_LEAVE(WE_LOG_DIGEST, "we_sha224_final", ret);
 
     return ret;
 }
@@ -254,11 +254,11 @@ static int we_sha224_final(EVP_MD_CTX *ctx, unsigned char *md)
  */
 static int we_sha224_cleanup(EVP_MD_CTX *ctx)
 {
-    WOLFENGINE_ENTER("we_sha224_cleanup");
+    WOLFENGINE_ENTER(WE_LOG_DIGEST, "we_sha224_cleanup");
 
     wc_Sha224Free((wc_Sha224*)EVP_MD_CTX_md_data(ctx));
 
-    WOLFENGINE_LEAVE("we_sha224_cleanup", 1);
+    WOLFENGINE_LEAVE(WE_LOG_DIGEST, "we_sha224_cleanup", 1);
     return 1;
 }
 
@@ -274,7 +274,7 @@ int we_init_sha224_meth()
 {
     int ret;
 
-    WOLFENGINE_ENTER("we_init_sha224_meth");
+    WOLFENGINE_ENTER(WE_LOG_DIGEST, "we_init_sha224_meth");
 
     ret = (we_sha224_md = EVP_MD_meth_new(NID_sha224, EVP_PKEY_NONE)) != NULL;
     if (ret == 1) {
@@ -300,7 +300,7 @@ int we_init_sha224_meth()
         EVP_MD_meth_free(we_sha224_md);
     }
 
-    WOLFENGINE_LEAVE("we_init_sha224_meth", ret);
+    WOLFENGINE_LEAVE(WE_LOG_DIGEST, "we_init_sha224_meth", ret);
 
     return ret;
 };
@@ -323,15 +323,15 @@ static int we_sha256_init(EVP_MD_CTX *ctx)
 {
     int ret = 1, rc;
 
-    WOLFENGINE_ENTER("we_sha256_init");
+    WOLFENGINE_ENTER(WE_LOG_DIGEST, "we_sha256_init");
 
     rc = wc_InitSha256((wc_Sha256*)EVP_MD_CTX_md_data(ctx));
     if (rc != 0) {
-        WOLFENGINE_ERROR_FUNC("wc_InitSha256", rc);
+        WOLFENGINE_ERROR_FUNC(WE_LOG_DIGEST, "wc_InitSha256", rc);
         ret = 0;
     }
 
-    WOLFENGINE_LEAVE("we_sha256_init", ret);
+    WOLFENGINE_LEAVE(WE_LOG_DIGEST, "we_sha256_init", ret);
 
     return ret;
 }
@@ -348,16 +348,16 @@ static int we_sha256_update(EVP_MD_CTX *ctx, const void *data, size_t len)
 {
     int ret = 1, rc;
 
-    WOLFENGINE_ENTER("we_sha256_update");
+    WOLFENGINE_ENTER(WE_LOG_DIGEST, "we_sha256_update");
 
     rc = wc_Sha256Update((wc_Sha256*)EVP_MD_CTX_md_data(ctx),
                          (const byte*)data, (word32)len);
     if (rc != 0) {
-        WOLFENGINE_ERROR_FUNC("wc_Sha256Update", rc);
+        WOLFENGINE_ERROR_FUNC(WE_LOG_DIGEST, "wc_Sha256Update", rc);
         ret = 0;
     }
 
-    WOLFENGINE_LEAVE("we_sha256_update", ret);
+    WOLFENGINE_LEAVE(WE_LOG_DIGEST, "we_sha256_update", ret);
 
     return ret;
 }
@@ -373,18 +373,18 @@ static int we_sha256_final(EVP_MD_CTX *ctx, unsigned char *md)
 {
     int ret = 1, rc;
 
-    WOLFENGINE_ENTER("we_sha256_final");
+    WOLFENGINE_ENTER(WE_LOG_DIGEST, "we_sha256_final");
 
     rc = wc_Sha256Final((wc_Sha256*)EVP_MD_CTX_md_data(ctx), (byte*)md);
     if (rc != 0) {
-        WOLFENGINE_ERROR_FUNC("wc_Sha256Final", rc);
+        WOLFENGINE_ERROR_FUNC(WE_LOG_DIGEST, "wc_Sha256Final", rc);
         ret = 0;
     } else {
-        WOLFENGINE_MSG("SHA-256 Digest");
-        WOLFENGINE_BUFFER(md, WC_SHA256_DIGEST_SIZE);
+        WOLFENGINE_MSG(WE_LOG_DIGEST, "SHA-256 Digest");
+        WOLFENGINE_BUFFER(WE_LOG_DIGEST, md, WC_SHA256_DIGEST_SIZE);
     }
 
-    WOLFENGINE_LEAVE("we_sha256_final", ret);
+    WOLFENGINE_LEAVE(WE_LOG_DIGEST, "we_sha256_final", ret);
 
     return ret;
 }
@@ -397,11 +397,11 @@ static int we_sha256_final(EVP_MD_CTX *ctx, unsigned char *md)
  */
 static int we_sha256_cleanup(EVP_MD_CTX *ctx)
 {
-    WOLFENGINE_ENTER("we_sha256_cleanup");
+    WOLFENGINE_ENTER(WE_LOG_DIGEST, "we_sha256_cleanup");
 
     wc_Sha256Free((wc_Sha256*)EVP_MD_CTX_md_data(ctx));
 
-    WOLFENGINE_LEAVE("we_sha256_cleanup", 1);
+    WOLFENGINE_LEAVE(WE_LOG_DIGEST, "we_sha256_cleanup", 1);
     return 1;
 }
 
@@ -417,7 +417,7 @@ int we_init_sha256_meth()
 {
     int ret;
 
-    WOLFENGINE_ENTER("we_init_sha256_meth");
+    WOLFENGINE_ENTER(WE_LOG_DIGEST, "we_init_sha256_meth");
 
     ret = (we_sha256_md = EVP_MD_meth_new(NID_sha256, EVP_PKEY_NONE)) != NULL;
     if (ret == 1) {
@@ -443,7 +443,7 @@ int we_init_sha256_meth()
         EVP_MD_meth_free(we_sha256_md);
     }
 
-    WOLFENGINE_LEAVE("we_init_sha256_meth", ret);
+    WOLFENGINE_LEAVE(WE_LOG_DIGEST, "we_init_sha256_meth", ret);
 
     return ret;
 };
@@ -475,18 +475,18 @@ static int we_sha_init(EVP_MD_CTX *ctx)
     int ret = 1, rc;
     we_Digest *digest;
 
-    WOLFENGINE_ENTER("we_sha_init");
+    WOLFENGINE_ENTER(WE_LOG_DIGEST, "we_sha_init");
 
     digest = (we_Digest *)EVP_MD_CTX_md_data(ctx);
     digest->hashType = WC_HASH_TYPE_SHA;
 
     rc = wc_HashInit(&digest->hash, digest->hashType);
     if (rc != 0) {
-        WOLFENGINE_ERROR_FUNC("wc_HashInit", rc);
+        WOLFENGINE_ERROR_FUNC(WE_LOG_DIGEST, "wc_HashInit", rc);
         ret = 0;
     }
 
-    WOLFENGINE_LEAVE("we_sha_init", ret);
+    WOLFENGINE_LEAVE(WE_LOG_DIGEST, "we_sha_init", ret);
 
     return ret;
 }
@@ -504,18 +504,18 @@ static int we_sha224_init(EVP_MD_CTX *ctx)
     int ret = 1, rc;
     we_Digest *digest;
 
-    WOLFENGINE_ENTER("we_sha224_init");
+    WOLFENGINE_ENTER(WE_LOG_DIGEST, "we_sha224_init");
 
     digest = (we_Digest *)EVP_MD_CTX_md_data(ctx);
     digest->hashType = WC_HASH_TYPE_SHA224;
 
     rc = wc_HashInit(&digest->hash, digest->hashType);
     if (rc != 0) {
-        WOLFENGINE_ERROR_FUNC("wc_HashInit", rc);
+        WOLFENGINE_ERROR_FUNC(WE_LOG_DIGEST, "wc_HashInit", rc);
         ret = 0;
     }
 
-    WOLFENGINE_LEAVE("we_sha224_init", ret);
+    WOLFENGINE_LEAVE(WE_LOG_DIGEST, "we_sha224_init", ret);
 
     return ret;
 }
@@ -533,18 +533,18 @@ static int we_sha256_init(EVP_MD_CTX *ctx)
     int ret = 1, rc;
     we_Digest *digest;
 
-    WOLFENGINE_ENTER("we_sha256_init");
+    WOLFENGINE_ENTER(WE_LOG_DIGEST, "we_sha256_init");
 
     digest = (we_Digest *)EVP_MD_CTX_md_data(ctx);
     digest->hashType = WC_HASH_TYPE_SHA256;
 
     rc = wc_HashInit(&digest->hash, digest->hashType);
     if (rc != 0) {
-        WOLFENGINE_ERROR_FUNC("wc_HashInit", rc);
+        WOLFENGINE_ERROR_FUNC(WE_LOG_DIGEST, "wc_HashInit", rc);
         ret = 0;
     }
 
-    WOLFENGINE_LEAVE("we_sha256_init", ret);
+    WOLFENGINE_LEAVE(WE_LOG_DIGEST, "we_sha256_init", ret);
 
     return ret;
 }
@@ -562,18 +562,18 @@ static int we_sha384_init(EVP_MD_CTX *ctx)
     int ret = 1, rc;
     we_Digest *digest;
 
-    WOLFENGINE_ENTER("we_sha384_init");
+    WOLFENGINE_ENTER(WE_LOG_DIGEST, "we_sha384_init");
 
     digest = (we_Digest *)EVP_MD_CTX_md_data(ctx);
     digest->hashType = WC_HASH_TYPE_SHA384;
 
     rc = wc_HashInit(&digest->hash, digest->hashType);
     if (rc != 0) {
-        WOLFENGINE_ERROR_FUNC("wc_HashInit", rc);
+        WOLFENGINE_ERROR_FUNC(WE_LOG_DIGEST, "wc_HashInit", rc);
         ret = 0;
     }
 
-    WOLFENGINE_LEAVE("we_sha384_init", ret);
+    WOLFENGINE_LEAVE(WE_LOG_DIGEST, "we_sha384_init", ret);
 
     return ret;
 }
@@ -591,18 +591,18 @@ static int we_sha512_init(EVP_MD_CTX *ctx)
     int ret = 1, rc;
     we_Digest *digest;
 
-    WOLFENGINE_ENTER("we_sha512_init");
+    WOLFENGINE_ENTER(WE_LOG_DIGEST, "we_sha512_init");
 
     digest = (we_Digest *)EVP_MD_CTX_md_data(ctx);
     digest->hashType = WC_HASH_TYPE_SHA512;
 
     rc = wc_HashInit(&digest->hash, digest->hashType);
     if (rc != 0) {
-        WOLFENGINE_ERROR_FUNC("wc_HashInit", rc);
+        WOLFENGINE_ERROR_FUNC(WE_LOG_DIGEST, "wc_HashInit", rc);
         ret = 0;
     }
 
-    WOLFENGINE_LEAVE("we_sha512_init", ret);
+    WOLFENGINE_LEAVE(WE_LOG_DIGEST, "we_sha512_init", ret);
 
     return ret;
 }
@@ -620,18 +620,18 @@ static int we_sha3_224_init(EVP_MD_CTX *ctx)
     int ret = 1, rc;
     we_Digest *digest;
 
-    WOLFENGINE_ENTER("we_sha3_224_init");
+    WOLFENGINE_ENTER(WE_LOG_DIGEST, "we_sha3_224_init");
 
     digest = (we_Digest *)EVP_MD_CTX_md_data(ctx);
     digest->hashType = WC_HASH_TYPE_SHA3_224;
 
     rc = wc_HashInit(&digest->hash, digest->hashType);
     if (rc != 0) {
-        WOLFENGINE_ERROR_FUNC("wc_HashInit", rc);
+        WOLFENGINE_ERROR_FUNC(WE_LOG_DIGEST, "wc_HashInit", rc);
         ret = 0;
     }
 
-    WOLFENGINE_LEAVE("we_sha3_224_init", ret);
+    WOLFENGINE_LEAVE(WE_LOG_DIGEST, "we_sha3_224_init", ret);
 
     return ret;
 }
@@ -649,18 +649,18 @@ static int we_sha3_256_init(EVP_MD_CTX *ctx)
     int ret = 1, rc;
     we_Digest *digest;
 
-    WOLFENGINE_ENTER("we_sha3_256_init");
+    WOLFENGINE_ENTER(WE_LOG_DIGEST, "we_sha3_256_init");
 
     digest = (we_Digest *)EVP_MD_CTX_md_data(ctx);
     digest->hashType = WC_HASH_TYPE_SHA3_256;
 
     rc = wc_HashInit(&digest->hash, digest->hashType);
     if (rc != 0) {
-        WOLFENGINE_ERROR_FUNC("wc_HashInit", rc);
+        WOLFENGINE_ERROR_FUNC(WE_LOG_DIGEST, "wc_HashInit", rc);
         ret = 0;
     }
 
-    WOLFENGINE_LEAVE("we_sha3_256_init", ret);
+    WOLFENGINE_LEAVE(WE_LOG_DIGEST, "we_sha3_256_init", ret);
 
     return ret;
 }
@@ -678,18 +678,18 @@ static int we_sha3_384_init(EVP_MD_CTX *ctx)
     int ret = 1, rc;
     we_Digest *digest;
 
-    WOLFENGINE_ENTER("we_sha3_384_init");
+    WOLFENGINE_ENTER(WE_LOG_DIGEST, "we_sha3_384_init");
 
     digest = (we_Digest *)EVP_MD_CTX_md_data(ctx);
     digest->hashType = WC_HASH_TYPE_SHA3_384;
 
     rc = wc_HashInit(&digest->hash, digest->hashType);
     if (rc != 0) {
-        WOLFENGINE_ERROR_FUNC("wc_HashInit", rc);
+        WOLFENGINE_ERROR_FUNC(WE_LOG_DIGEST, "wc_HashInit", rc);
         ret = 0;
     }
 
-    WOLFENGINE_LEAVE("we_sha3_384_init", ret);
+    WOLFENGINE_LEAVE(WE_LOG_DIGEST, "we_sha3_384_init", ret);
 
     return ret;
 }
@@ -707,18 +707,18 @@ static int we_sha3_512_init(EVP_MD_CTX *ctx)
     int ret = 1, rc;
     we_Digest *digest;
 
-    WOLFENGINE_ENTER("we_sha3_512_init");
+    WOLFENGINE_ENTER(WE_LOG_DIGEST, "we_sha3_512_init");
 
     digest = (we_Digest *)EVP_MD_CTX_md_data(ctx);
     digest->hashType = WC_HASH_TYPE_SHA3_512;
 
     rc = wc_HashInit(&digest->hash, digest->hashType);
     if (rc != 0) {
-        WOLFENGINE_ERROR_FUNC("wc_HashInit", rc);
+        WOLFENGINE_ERROR_FUNC(WE_LOG_DIGEST, "wc_HashInit", rc);
         ret = 0;
     }
 
-    WOLFENGINE_LEAVE("we_sha3_512_init", ret);
+    WOLFENGINE_LEAVE(WE_LOG_DIGEST, "we_sha3_512_init", ret);
 
     return ret;
 }
@@ -737,18 +737,18 @@ static int we_digest_update(EVP_MD_CTX *ctx, const void *data, size_t len)
     int ret = 1, rc;
     we_Digest *digest;
 
-    WOLFENGINE_ENTER("we_digest_update");
+    WOLFENGINE_ENTER(WE_LOG_DIGEST, "we_digest_update");
 
     digest = (we_Digest *)EVP_MD_CTX_md_data(ctx);
 
     rc = wc_HashUpdate(&digest->hash, digest->hashType, (const byte*)data,
                        (word32)len);
     if (rc != 0) {
-        WOLFENGINE_ERROR_FUNC("wc_HashUpdate", rc);
+        WOLFENGINE_ERROR_FUNC(WE_LOG_DIGEST, "wc_HashUpdate", rc);
         ret = 0;
     }
 
-    WOLFENGINE_LEAVE("we_digest_update", ret);
+    WOLFENGINE_LEAVE(WE_LOG_DIGEST, "we_digest_update", ret);
 
     return ret;
 }
@@ -765,20 +765,21 @@ static int we_digest_final(EVP_MD_CTX *ctx, unsigned char *md)
     int ret = 1, rc;
     we_Digest *digest;
 
-    WOLFENGINE_ENTER("we_digest_final");
+    WOLFENGINE_ENTER(WE_LOG_DIGEST, "we_digest_final");
 
     digest = (we_Digest *)EVP_MD_CTX_md_data(ctx);
 
     rc = wc_HashFinal(&digest->hash, digest->hashType, (byte*)md);
     if (rc != 0) {
-        WOLFENGINE_ERROR_FUNC("wc_HashFinal", rc);
+        WOLFENGINE_ERROR_FUNC(WE_LOG_DIGEST, "wc_HashFinal", rc);
         ret = 0;
     } else {
-        WOLFENGINE_MSG("Message Digest");
-        WOLFENGINE_BUFFER(md, wc_HashGetDigestSize(digest->hashType));
+        WOLFENGINE_MSG(WE_LOG_DIGEST, "Message Digest");
+        WOLFENGINE_BUFFER(WE_LOG_DIGEST, md,
+                          wc_HashGetDigestSize(digest->hashType));
     }
 
-    WOLFENGINE_LEAVE("we_digest_final", ret);
+    WOLFENGINE_LEAVE(WE_LOG_DIGEST, "we_digest_final", ret);
 
     return ret;
 }
@@ -795,25 +796,25 @@ static int we_digest_cleanup(EVP_MD_CTX *ctx)
 #if !defined(HAVE_FIPS_VERSION) || HAVE_FIPS_VERSION >= 2
     we_Digest *digest;
 
-    WOLFENGINE_ENTER("we_digest_cleanup");
+    WOLFENGINE_ENTER(WE_LOG_DIGEST, "we_digest_cleanup");
 
     digest = (we_Digest *)EVP_MD_CTX_md_data(ctx);
 
     if (digest != NULL) {
         rc = wc_HashFree(&digest->hash, digest->hashType);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_HashFree", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_DIGEST, "wc_HashFree", rc);
             ret = 0;
         }
     }
 #else
-    WOLFENGINE_ENTER("we_digest_cleanup");
+    WOLFENGINE_ENTER(WE_LOG_DIGEST, "we_digest_cleanup");
 
     (void)ctx;
     ret = 1; 
 #endif
 
-    WOLFENGINE_LEAVE("we_digest_cleanup", ret);
+    WOLFENGINE_LEAVE(WE_LOG_DIGEST, "we_digest_cleanup", ret);
     return ret;
 }
 
@@ -827,7 +828,7 @@ static int we_init_digest_meth(EVP_MD *method)
 {
     int ret;
 
-    WOLFENGINE_ENTER("we_init_digest_meth");
+    WOLFENGINE_ENTER(WE_LOG_DIGEST, "we_init_digest_meth");
 
     ret = EVP_MD_meth_set_update(method, we_digest_update);
     if (ret == 1) {
@@ -853,7 +854,7 @@ static int we_init_digest_meth(EVP_MD *method)
 #endif
 #endif
 
-    WOLFENGINE_LEAVE("we_init_digest_meth", ret);
+    WOLFENGINE_LEAVE(WE_LOG_DIGEST, "we_init_digest_meth", ret);
 
     return ret;
 }
@@ -871,7 +872,7 @@ int we_init_sha_meth()
 {
     int ret;
 
-    WOLFENGINE_ENTER("we_init_sha_meth");
+    WOLFENGINE_ENTER(WE_LOG_DIGEST, "we_init_sha_meth");
 
     ret = (we_sha1_md = EVP_MD_meth_new(NID_sha1, EVP_PKEY_NONE)) != NULL;
     if (ret == 1) {
@@ -888,7 +889,7 @@ int we_init_sha_meth()
         EVP_MD_meth_free(we_sha1_md);
     }
 
-    WOLFENGINE_LEAVE("we_init_sha_meth", ret);
+    WOLFENGINE_LEAVE(WE_LOG_DIGEST, "we_init_sha_meth", ret);
 
     return ret;
 };
@@ -907,7 +908,7 @@ int we_init_sha224_meth()
 {
     int ret;
 
-    WOLFENGINE_ENTER("we_init_sha224_meth");
+    WOLFENGINE_ENTER(WE_LOG_DIGEST, "we_init_sha224_meth");
 
     ret = (we_sha224_md = EVP_MD_meth_new(NID_sha256, EVP_PKEY_NONE)) != NULL;
     if (ret == 1) {
@@ -924,7 +925,7 @@ int we_init_sha224_meth()
         EVP_MD_meth_free(we_sha224_md);
     }
 
-    WOLFENGINE_LEAVE("we_init_sha224_meth", ret);
+    WOLFENGINE_LEAVE(WE_LOG_DIGEST, "we_init_sha224_meth", ret);
 
     return ret;
 };
@@ -943,7 +944,7 @@ int we_init_sha256_meth()
 {
     int ret;
 
-    WOLFENGINE_ENTER("we_init_sha256_meth");
+    WOLFENGINE_ENTER(WE_LOG_DIGEST, "we_init_sha256_meth");
 
     ret = (we_sha256_md = EVP_MD_meth_new(NID_sha256, EVP_PKEY_NONE)) != NULL;
     if (ret == 1) {
@@ -960,7 +961,7 @@ int we_init_sha256_meth()
         EVP_MD_meth_free(we_sha256_md);
     }
 
-    WOLFENGINE_LEAVE("we_init_sha256_meth", ret);
+    WOLFENGINE_LEAVE(WE_LOG_DIGEST, "we_init_sha256_meth", ret);
 
     return ret;
 };
@@ -979,7 +980,7 @@ int we_init_sha384_meth()
 {
     int ret;
 
-    WOLFENGINE_ENTER("we_init_sha384_meth");
+    WOLFENGINE_ENTER(WE_LOG_DIGEST, "we_init_sha384_meth");
 
     ret = (we_sha384_md = EVP_MD_meth_new(NID_sha384, EVP_PKEY_NONE)) != NULL;
     if (ret == 1) {
@@ -996,7 +997,7 @@ int we_init_sha384_meth()
         EVP_MD_meth_free(we_sha384_md);
     }
 
-    WOLFENGINE_LEAVE("we_init_sha384_meth", ret);
+    WOLFENGINE_LEAVE(WE_LOG_DIGEST, "we_init_sha384_meth", ret);
 
     return ret;
 };
@@ -1015,7 +1016,7 @@ int we_init_sha512_meth()
 {
     int ret = 1;
 
-    WOLFENGINE_ENTER("we_init_sha512_meth");
+    WOLFENGINE_ENTER(WE_LOG_DIGEST, "we_init_sha512_meth");
 
     ret = (we_sha512_md = EVP_MD_meth_new(NID_sha512, EVP_PKEY_NONE)) != NULL;
     if (ret == 1) {
@@ -1032,7 +1033,7 @@ int we_init_sha512_meth()
         EVP_MD_meth_free(we_sha512_md);
     }
 
-    WOLFENGINE_LEAVE("we_init_sha512_meth", ret);
+    WOLFENGINE_LEAVE(WE_LOG_DIGEST, "we_init_sha512_meth", ret);
 
     return ret;
 };
@@ -1051,7 +1052,7 @@ int we_init_sha3_224_meth()
 {
     int ret = 1;
 
-    WOLFENGINE_ENTER("we_init_sha3_224_meth");
+    WOLFENGINE_ENTER(WE_LOG_DIGEST, "we_init_sha3_224_meth");
 
     ret = (we_sha3_224_md = EVP_MD_meth_new(NID_sha3_224,
                                             EVP_PKEY_NONE)) != NULL;
@@ -1070,7 +1071,7 @@ int we_init_sha3_224_meth()
         EVP_MD_meth_free(we_sha3_224_md);
     }
 
-    WOLFENGINE_LEAVE("we_init_sha3_224_meth", ret);
+    WOLFENGINE_LEAVE(WE_LOG_DIGEST, "we_init_sha3_224_meth", ret);
 
     return ret;
 };
@@ -1089,7 +1090,7 @@ int we_init_sha3_256_meth()
 {
     int ret = 1;
 
-    WOLFENGINE_ENTER("we_init_sha3_256_meth");
+    WOLFENGINE_ENTER(WE_LOG_DIGEST, "we_init_sha3_256_meth");
 
     ret = (we_sha3_256_md = EVP_MD_meth_new(NID_sha3_256,
                                             EVP_PKEY_NONE)) != NULL;
@@ -1108,7 +1109,7 @@ int we_init_sha3_256_meth()
         EVP_MD_meth_free(we_sha3_256_md);
     }
 
-    WOLFENGINE_LEAVE("we_init_sha3_256_meth", ret);
+    WOLFENGINE_LEAVE(WE_LOG_DIGEST, "we_init_sha3_256_meth", ret);
 
     return ret;
 };
@@ -1127,7 +1128,7 @@ int we_init_sha3_384_meth()
 {
     int ret = 1;
 
-    WOLFENGINE_ENTER("we_init_sha3_384_meth");
+    WOLFENGINE_ENTER(WE_LOG_DIGEST, "we_init_sha3_384_meth");
 
     ret = (we_sha3_384_md = EVP_MD_meth_new(NID_sha3_384,
                                             EVP_PKEY_NONE)) != NULL;
@@ -1146,7 +1147,7 @@ int we_init_sha3_384_meth()
         EVP_MD_meth_free(we_sha3_384_md);
     }
 
-    WOLFENGINE_LEAVE("we_init_sha3_384_meth", ret);
+    WOLFENGINE_LEAVE(WE_LOG_DIGEST, "we_init_sha3_384_meth", ret);
 
     return ret;
 };
@@ -1165,7 +1166,7 @@ int we_init_sha3_512_meth()
 {
     int ret = 1;
 
-    WOLFENGINE_ENTER("we_init_sha3_512_meth");
+    WOLFENGINE_ENTER(WE_LOG_DIGEST, "we_init_sha3_512_meth");
 
     ret = (we_sha3_512_md = EVP_MD_meth_new(NID_sha3_512,
                                             EVP_PKEY_NONE)) != NULL;
@@ -1184,7 +1185,7 @@ int we_init_sha3_512_meth()
         EVP_MD_meth_free(we_sha3_512_md);
     }
 
-    WOLFENGINE_LEAVE("we_init_sha3_512_meth", ret);
+    WOLFENGINE_LEAVE(WE_LOG_DIGEST, "we_init_sha3_512_meth", ret);
 
     return ret;
 };

--- a/src/ecc.c
+++ b/src/ecc.c
@@ -37,46 +37,46 @@ static int we_ec_get_curve_id(int curveName, int *curveId)
 {
     int ret = 1;
 
-    WOLFENGINE_ENTER("we_ec_get_curve_id");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_ec_get_curve_id");
 
     switch (curveName) {
 #ifdef WE_HAVE_EC_P192
         case NID_X9_62_prime192v1:
-            WOLFENGINE_MSG("Set P-192");
+            WOLFENGINE_MSG(WE_LOG_PK, "Set P-192");
             *curveId = ECC_SECP192R1;
             break;
 #endif
 #ifdef WE_HAVE_EC_P224
         case NID_secp224r1:
-            WOLFENGINE_MSG("Set P-224");
+            WOLFENGINE_MSG(WE_LOG_PK, "Set P-224");
             *curveId = ECC_SECP224R1;
             break;
 #endif
 #ifdef WE_HAVE_EC_P256
         case NID_X9_62_prime256v1:
-            WOLFENGINE_MSG("Set P-256");
+            WOLFENGINE_MSG(WE_LOG_PK, "Set P-256");
             *curveId = ECC_SECP256R1;
             break;
 #endif
 #ifdef WE_HAVE_EC_P384
         case NID_secp384r1:
-            WOLFENGINE_MSG("Set P-384");
+            WOLFENGINE_MSG(WE_LOG_PK, "Set P-384");
             *curveId = ECC_SECP384R1;
             break;
 #endif
 #ifdef WE_HAVE_EC_P521
         case NID_secp521r1:
-            WOLFENGINE_MSG("Set P-521");
+            WOLFENGINE_MSG(WE_LOG_PK, "Set P-521");
             *curveId = ECC_SECP521R1;
             break;
 #endif
         default:
-            WOLFENGINE_ERROR_MSG("Unsupported ECC curve name");
+            WOLFENGINE_ERROR_MSG(WE_LOG_PK, "Unsupported ECC curve name");
             ret = 0;
             break;
     }
 
-    WOLFENGINE_LEAVE("we_ec_get_curve_id", ret);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_ec_get_curve_id", ret);
 
     return ret;
 }
@@ -95,12 +95,12 @@ static int we_ec_set_private(ecc_key *key, int curveId, const EC_KEY *ecKey)
     size_t privLen = 0;
     unsigned char* privBuf = NULL;
 
-    WOLFENGINE_ENTER("we_ec_set_private");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_ec_set_private");
 
     /* Get the EC key private key as binary data. */
     privLen = EC_KEY_priv2buf(ecKey, &privBuf);
     if (privLen <= 0) {
-        WOLFENGINE_ERROR_FUNC("EC_KEY_priv2buf", (int)privLen);
+        WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "EC_KEY_priv2buf", (int)privLen);
         ret = 0;
     }
     /* Import private key. */
@@ -108,7 +108,8 @@ static int we_ec_set_private(ecc_key *key, int curveId, const EC_KEY *ecKey)
         rc = wc_ecc_import_private_key_ex(privBuf, (word32)privLen, NULL, 0,
                                           key, curveId);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_ecc_import_private_key_ex", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK,
+                                  "wc_ecc_import_private_key_ex", rc);
             ret = 0;
         }
     }
@@ -118,7 +119,7 @@ static int we_ec_set_private(ecc_key *key, int curveId, const EC_KEY *ecKey)
         OPENSSL_clear_free(privBuf, privLen);
     }
 
-    WOLFENGINE_LEAVE("we_ec_set_private", ret);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_ec_set_private", ret);
 
     return ret;
 }
@@ -139,13 +140,13 @@ static int we_ec_set_public(ecc_key *key, int curveId, EC_KEY *ecKey)
     unsigned char* x;
     unsigned char* y;
 
-    WOLFENGINE_ENTER("we_ec_set_public");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_ec_set_public");
 
     /* Get the EC key public key as and uncompressed point. */
     pubLen = EC_KEY_key2buf(ecKey, POINT_CONVERSION_UNCOMPRESSED, &pubBuf,
                             NULL);
     if (pubLen <= 0) {
-        WOLFENGINE_ERROR_FUNC("EC_KEY_key2buf", (int)pubLen);
+        WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "EC_KEY_key2buf", (int)pubLen);
         ret = 0;
     }
 
@@ -156,14 +157,14 @@ static int we_ec_set_public(ecc_key *key, int curveId, EC_KEY *ecKey)
         y = x + ((pubLen - 1) / 2);
         rc = wc_ecc_import_unsigned(key, x, y, NULL, curveId);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_ecc_import_unsigned", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_ecc_import_unsigned", rc);
             ret = 0;
         }
     }
 
     OPENSSL_free(pubBuf);
 
-    WOLFENGINE_LEAVE("we_ec_set_public", ret);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_ec_set_public", ret);
 
     return ret;
 }
@@ -182,7 +183,7 @@ static int we_ec_export_key(ecc_key *ecc, int len, EC_KEY *key)
     unsigned char *buf = NULL;
     unsigned char *d = NULL;
 
-    WOLFENGINE_ENTER("we_ec_export_key");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_ec_export_key");
 
     /* Allocate buffer to hold private and public key data. */
     ret = (buf = (unsigned char *)OPENSSL_malloc(len * 3 + 1)) != NULL;
@@ -197,7 +198,7 @@ static int we_ec_export_key(ecc_key *ecc, int len, EC_KEY *key)
         /* Export public and private key data. */
         rc = wc_ecc_export_private_raw(ecc, x, &xLen, y, &yLen, d, &dLen);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_ecc_export_private", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_ecc_export_private", rc);
             ret = 0;
         }
     }
@@ -206,14 +207,14 @@ static int we_ec_export_key(ecc_key *ecc, int len, EC_KEY *key)
         buf[0] = ECC_POINT_UNCOMP;
         ret = EC_KEY_oct2key(key, buf, len * 2 + 1, NULL);
         if (ret == 0) {
-            WOLFENGINE_ERROR_FUNC("EC_KEY_oct2key", ret);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "EC_KEY_oct2key", ret);
         }
     }
     if (ret == 1) {
         /* Import private key. */
         ret = EC_KEY_oct2priv(key, d, len);
         if (ret == 0) {
-            WOLFENGINE_ERROR_FUNC("EC_KEY_oct2priv", ret);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "EC_KEY_oct2priv", ret);
         }
     }
 
@@ -221,7 +222,7 @@ static int we_ec_export_key(ecc_key *ecc, int len, EC_KEY *key)
         OPENSSL_clear_free(buf, len * 3 + 1);
     }
 
-    WOLFENGINE_LEAVE("we_ec_export_key", ret);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_ec_export_key", ret);
 
     return ret;
 }
@@ -270,7 +271,7 @@ static int we_ec_init(EVP_PKEY_CTX *ctx)
     we_Ecc *ecc;
     int keyInited = 0;
 
-    WOLFENGINE_ENTER("we_ec_init");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_ec_init");
 
     /* Allocate a new internal EC object. */
     ret = (ecc = (we_Ecc*)OPENSSL_zalloc(sizeof(we_Ecc))) != NULL;
@@ -280,7 +281,7 @@ static int we_ec_init(EVP_PKEY_CTX *ctx)
         if (rc == 0) {
             keyInited = 1;
         } else {
-            WOLFENGINE_ERROR_FUNC("wc_ecc_init", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_ecc_init", rc);
             ret = 0;
         }
     }
@@ -290,7 +291,7 @@ static int we_ec_init(EVP_PKEY_CTX *ctx)
         /* Set the random number generator for use in EC operations. */
         rc = wc_ecc_set_rng(&ecc->key, we_rng);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_ecc_set_rng", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_ecc_set_rng", rc);
             ret = 0;
         }
     }
@@ -309,7 +310,7 @@ static int we_ec_init(EVP_PKEY_CTX *ctx)
         OPENSSL_free(ecc);
     }
 
-    WOLFENGINE_LEAVE("we_ec_init", ret);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_ec_init", ret);
 
     return ret;
 }
@@ -328,7 +329,7 @@ static int we_ec_p192_init(EVP_PKEY_CTX *ctx)
     int ret;
     we_Ecc *ecc;
 
-    WOLFENGINE_ENTER("we_ec_p192_init");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_ec_p192_init");
 
     /* Create the internal EC object in context. */
     ret = we_ec_init(ctx);
@@ -341,7 +342,7 @@ static int we_ec_p192_init(EVP_PKEY_CTX *ctx)
         ecc->group = EC_GROUP_new_by_curve_name(ecc->curveName);
         if (ecc->group == NULL) {
             /* Failed - free allocated data. */
-            WOLFENGINE_ERROR_FUNC_NULL("EC_GROUP_new_by_curve_name",
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "EC_GROUP_new_by_curve_name",
                                        ecc->group);
             wc_ecc_free(&ecc->key);
             OPENSSL_free(ecc);
@@ -349,7 +350,7 @@ static int we_ec_p192_init(EVP_PKEY_CTX *ctx)
         }
     }
 
-    WOLFENGINE_LEAVE("we_ec_p192_init", ret);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_ec_p192_init", ret);
 
     return ret;
 }
@@ -366,7 +367,7 @@ static int we_ec_p224_init(EVP_PKEY_CTX *ctx)
     int ret;
     we_Ecc *ecc;
 
-    WOLFENGINE_ENTER("we_ec_p224_init");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_ec_p224_init");
 
     /* Create the internal EC object in context. */
     ret = we_ec_init(ctx);
@@ -379,7 +380,7 @@ static int we_ec_p224_init(EVP_PKEY_CTX *ctx)
         ecc->group = EC_GROUP_new_by_curve_name(ecc->curveName);
         if (ecc->group == NULL) {
             /* Failed - free allocated data. */
-            WOLFENGINE_ERROR_FUNC_NULL("EC_GROUP_new_by_curve_name",
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "EC_GROUP_new_by_curve_name",
                                        ecc->group);
             wc_ecc_free(&ecc->key);
             OPENSSL_free(ecc);
@@ -387,7 +388,7 @@ static int we_ec_p224_init(EVP_PKEY_CTX *ctx)
         }
     }
 
-    WOLFENGINE_LEAVE("we_ec_p224_init", ret);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_ec_p224_init", ret);
 
     return ret;
 }
@@ -405,7 +406,7 @@ static int we_ec_p256_init(EVP_PKEY_CTX *ctx)
     int ret;
     we_Ecc *ecc;
 
-    WOLFENGINE_ENTER("we_ec_p256_init");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_ec_p256_init");
 
     /* Create the internal EC object in context. */
     ret = we_ec_init(ctx);
@@ -418,7 +419,7 @@ static int we_ec_p256_init(EVP_PKEY_CTX *ctx)
         ecc->group = EC_GROUP_new_by_curve_name(ecc->curveName);
         if (ecc->group == NULL) {
             /* Failed - free allocated data. */
-            WOLFENGINE_ERROR_FUNC_NULL("EC_GROUP_new_by_curve_name",
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "EC_GROUP_new_by_curve_name",
                                        ecc->group);
             wc_ecc_free(&ecc->key);
             OPENSSL_free(ecc);
@@ -426,7 +427,7 @@ static int we_ec_p256_init(EVP_PKEY_CTX *ctx)
         }
     }
 
-    WOLFENGINE_LEAVE("we_ec_p256_init", ret);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_ec_p256_init", ret);
 
     return ret;
 }
@@ -444,7 +445,7 @@ static int we_ec_p384_init(EVP_PKEY_CTX *ctx)
     int ret;
     we_Ecc *ecc;
 
-    WOLFENGINE_ENTER("we_ec_p384_init");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_ec_p384_init");
 
     /* Create the internal EC object in context. */
     ret = we_ec_init(ctx);
@@ -457,7 +458,7 @@ static int we_ec_p384_init(EVP_PKEY_CTX *ctx)
         ecc->group = EC_GROUP_new_by_curve_name(ecc->curveName);
         if (ecc->group == NULL) {
             /* Failed - free allocated data. */
-            WOLFENGINE_ERROR_FUNC_NULL("EC_GROUP_new_by_curve_name",
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "EC_GROUP_new_by_curve_name",
                                        ecc->group);
             wc_ecc_free(&ecc->key);
             OPENSSL_free(ecc);
@@ -465,7 +466,7 @@ static int we_ec_p384_init(EVP_PKEY_CTX *ctx)
         }
     }
 
-    WOLFENGINE_LEAVE("we_ec_p384_init", ret);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_ec_p384_init", ret);
 
     return ret;
 }
@@ -484,7 +485,7 @@ static int we_ec_p521_init(EVP_PKEY_CTX *ctx)
     int ret;
     we_Ecc *ecc;
 
-    WOLFENGINE_ENTER("we_ec_p521_init");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_ec_p521_init");
 
     /* Create the internal EC object in context. */
     ret = we_ec_init(ctx);
@@ -497,7 +498,7 @@ static int we_ec_p521_init(EVP_PKEY_CTX *ctx)
         ecc->group = EC_GROUP_new_by_curve_name(ecc->curveName);
         if (ecc->group == NULL) {
             /* Failed - free allocated data. */
-            WOLFENGINE_ERROR_FUNC_NULL("EC_GROUP_new_by_curve_name",
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "EC_GROUP_new_by_curve_name",
                                        ecc->group);
             wc_ecc_free(&ecc->key);
             OPENSSL_free(ecc);
@@ -505,7 +506,7 @@ static int we_ec_p521_init(EVP_PKEY_CTX *ctx)
         }
     }
 
-    WOLFENGINE_LEAVE("we_ec_p521_init", ret);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_ec_p521_init", ret);
 
     return ret;
 }
@@ -526,13 +527,13 @@ static int we_ec_copy(EVP_PKEY_CTX *dst, const EVP_PKEY_CTX *src)
 static int we_ec_copy(EVP_PKEY_CTX *dst, EVP_PKEY_CTX *src)
 #endif
 {
-    WOLFENGINE_ENTER("we_ec_copy");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_ec_copy");
 
     /* Nothing to copy as src is empty. */
     (void)src;
     (void)dst;
 
-    WOLFENGINE_LEAVE("we_ec_copy", 1);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_ec_copy", 1);
 
     return 1;
 }
@@ -546,7 +547,7 @@ static void we_ec_cleanup(EVP_PKEY_CTX *ctx)
 {
     we_Ecc *ecc;
 
-    WOLFENGINE_ENTER("we_ec_cleanup");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_ec_cleanup");
     
     ecc = (we_Ecc *)EVP_PKEY_CTX_get_data(ctx);
     if (ecc != NULL) {
@@ -563,7 +564,7 @@ static void we_ec_cleanup(EVP_PKEY_CTX *ctx)
         EVP_PKEY_CTX_set_data(ctx, NULL);
     }
 
-    WOLFENGINE_LEAVE("we_ec_cleanup", 1);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_ec_cleanup", 1);
 }
 
 #if defined(WE_HAVE_ECDSA) || defined(WE_HAVE_ECDH)
@@ -581,7 +582,7 @@ static int we_ec_get_ec_key(EVP_PKEY_CTX *ctx, EC_KEY **ecKey, we_Ecc *ecc)
     EVP_PKEY *pkey;
     const EC_GROUP *group;
 
-    WOLFENGINE_ENTER("we_ec_get_ec_key");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_ec_get_ec_key");
 
     /* Get the EVP_PKEY object performing operation with. */
     ret = (pkey = EVP_PKEY_CTX_get0_pkey(ctx)) != NULL;
@@ -597,7 +598,8 @@ static int we_ec_get_ec_key(EVP_PKEY_CTX *ctx, EC_KEY **ecKey, we_Ecc *ecc)
         /* Retrieve group parameters to setup curve in wolfSSL object. */
         group = EC_KEY_get0_group(*ecKey);
         if (group == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("EC_KEY_get0_group", (EC_GROUP*)group);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "EC_KEY_get0_group",
+                                       (EC_GROUP*)group);
             ret = 0;
         }
     }
@@ -607,7 +609,7 @@ static int we_ec_get_ec_key(EVP_PKEY_CTX *ctx, EC_KEY **ecKey, we_Ecc *ecc)
                                   &ecc->curveId);
     }
 
-    WOLFENGINE_LEAVE("we_ec_get_ec_key", ret);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_ec_get_ec_key", ret);
 
     return ret;
 }
@@ -633,7 +635,7 @@ static int we_ecdsa_sign(EVP_PKEY_CTX *ctx, unsigned char *sig, size_t *sigLen,
     we_Ecc *ecc;
     EC_KEY *ecKey = NULL;
 
-    WOLFENGINE_ENTER("we_ecdsa_sign");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_ecdsa_sign");
 
     /* Get the internal EC key object. */
     ret = (ecc = (we_Ecc *)EVP_PKEY_CTX_get_data(ctx)) != NULL;
@@ -660,7 +662,7 @@ static int we_ecdsa_sign(EVP_PKEY_CTX *ctx, unsigned char *sig, size_t *sigLen,
         rc = wc_ecc_sign_hash(tbs, (word32)tbsLen, sig, &outLen, we_rng,
                               &ecc->key);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_ecc_sign_hash", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_ecc_sign_hash", rc);
             ret = 0;
         }
         if (ret == 1) {
@@ -669,7 +671,7 @@ static int we_ecdsa_sign(EVP_PKEY_CTX *ctx, unsigned char *sig, size_t *sigLen,
         }
     }
 
-    WOLFENGINE_LEAVE("we_ecdsa_sign", ret);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_ecdsa_sign", ret);
 
     return ret;
 }
@@ -693,7 +695,7 @@ static int we_ecdsa_verify(EVP_PKEY_CTX *ctx, const unsigned char *sig,
     EC_KEY *ecKey = NULL;
     int res;
 
-    WOLFENGINE_ENTER("we_ecdsa_verify");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_ecdsa_verify");
 
     /* Get the internal EC key object. */
     ret = (ecc = (we_Ecc *)EVP_PKEY_CTX_get_data(ctx)) != NULL;
@@ -714,7 +716,7 @@ static int we_ecdsa_verify(EVP_PKEY_CTX *ctx, const unsigned char *sig,
         rc = wc_ecc_verify_hash(sig, (word32)sigLen, tbs, (word32)tbsLen, &res,
                                 &ecc->key);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_ecc_verify_hash", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_ecc_verify_hash", rc);
             ret = 0;
         }
     }
@@ -723,7 +725,7 @@ static int we_ecdsa_verify(EVP_PKEY_CTX *ctx, const unsigned char *sig,
         ret = res;
     }
 
-    WOLFENGINE_LEAVE("we_ecdsa_verify", ret);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_ecdsa_verify", ret);
 
     return ret;
 }
@@ -745,14 +747,15 @@ static int we_ec_keygen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
     EVP_PKEY *ctxPkey;
     int len = 0;
 
-    WOLFENGINE_ENTER("we_ec_keygen");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_ec_keygen");
 
     /* Get the internal EC key object. */
     ret = (ecc = (we_Ecc *)EVP_PKEY_CTX_get_data(ctx)) != NULL;
     if (ret == 1) {
         len = wc_ecc_get_curve_size_from_id(ecc->curveId);
         if (len < 0) {
-            WOLFENGINE_ERROR_FUNC("wc_ecc_get_curve_size_from_id", len);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK,
+                                  "wc_ecc_get_curve_size_from_id", len);
         }
 
         ctxPkey = EVP_PKEY_CTX_get0_pkey(ctx);
@@ -766,7 +769,7 @@ static int we_ec_keygen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
         /* EVP_PKEY object needs an EC_KEY object. */
         ret = EVP_PKEY_assign_EC_KEY(pkey, ecKey);
         if (ret == 0) {
-            WOLFENGINE_ERROR_FUNC("EVP_PKEY_assign_EC_KEY", ret);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "EVP_PKEY_assign_EC_KEY", ret);
             EC_KEY_free(ecKey);
         }
     }
@@ -786,7 +789,7 @@ static int we_ec_keygen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
         /* Generate a new EC key with wolfSSL. */
         rc = wc_ecc_make_key_ex(we_rng, len, &ecc->key, ecc->curveId);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_ecc_make_key_ex", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_ecc_make_key_ex", rc);
             ret = 0;
         }
     }
@@ -799,7 +802,7 @@ static int we_ec_keygen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
         ret = we_ec_export_key(&ecc->key, len, ecKey);
     }
 
-    WOLFENGINE_LEAVE("we_ec_keygen", ret);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_ec_keygen", ret);
 
     return ret;
 }
@@ -823,7 +826,7 @@ static int we_ecdh_derive(EVP_PKEY_CTX *ctx, unsigned char *key, size_t *keyLen)
     word32 len = (word32)*keyLen;
     ecc_key peer;
 
-    WOLFENGINE_ENTER("we_ecdh_derive");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_ecdh_derive");
 
     /* Get the internal EC key object. */
     ret = (ecc = (we_Ecc *)EVP_PKEY_CTX_get_data(ctx)) != NULL;
@@ -844,7 +847,8 @@ static int we_ecdh_derive(EVP_PKEY_CTX *ctx, unsigned char *key, size_t *keyLen)
         /* Return secret size in bytes. */
         rc = wc_ecc_get_curve_size_from_id(ecc->curveId);
         if (rc < 0) {
-            WOLFENGINE_ERROR_FUNC("wc_ecc_get_curve_size_from_id", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK,
+                                  "wc_ecc_get_curve_size_from_id", rc);
         } else {
             *keyLen = (size_t)rc;
         }
@@ -853,7 +857,7 @@ static int we_ecdh_derive(EVP_PKEY_CTX *ctx, unsigned char *key, size_t *keyLen)
         /* Create a new wolfSSL ECC key and set peer's public key. */
         rc = wc_ecc_init(&peer);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_ecc_init", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_ecc_init", rc);
             ret = 0;
         } else {
             /* Format of peer's public key point:
@@ -865,7 +869,7 @@ static int we_ecdh_derive(EVP_PKEY_CTX *ctx, unsigned char *key, size_t *keyLen)
             /* Import public key into wolfSSL object. */
             rc = wc_ecc_import_unsigned(&peer, x, y, NULL, ecc->curveId);
             if (rc != 0) {
-                WOLFENGINE_ERROR_FUNC("wc_ecc_import_unsigned", rc);
+                WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_ecc_import_unsigned", rc);
                 ret = 0;
             }
 
@@ -873,7 +877,8 @@ static int we_ecdh_derive(EVP_PKEY_CTX *ctx, unsigned char *key, size_t *keyLen)
                 /* Calculate shared secret using wolfSSL. */
                 rc = wc_ecc_shared_secret(&ecc->key, &peer, key, &len);
                 if (rc != 0) {
-                    WOLFENGINE_ERROR_FUNC("wc_ecc_shared_secret", rc);
+                    WOLFENGINE_ERROR_FUNC(WE_LOG_PK,
+                                          "wc_ecc_shared_secret", rc);
                     ret = 0;
                 }
             }
@@ -887,7 +892,7 @@ static int we_ecdh_derive(EVP_PKEY_CTX *ctx, unsigned char *key, size_t *keyLen)
         }
     }
 
-    WOLFENGINE_LEAVE("we_ecdh_derive", ret);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_ecdh_derive", ret);
 
     return ret;
 }
@@ -917,11 +922,11 @@ static int we_ec_ctrl(EVP_PKEY_CTX *ctx, int type, int num, void *ptr)
     (void)num;
     (void)ptr;
 
-    WOLFENGINE_ENTER("we_ec_ctrl");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_ec_ctrl");
 
     ecc = (we_Ecc *)EVP_PKEY_CTX_get_data(ctx);
     if (ecc == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("EVP_PKEY_CTX_get_data", ecc);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "EVP_PKEY_CTX_get_data", ecc);
         ret = 0;
     }
 
@@ -930,20 +935,21 @@ static int we_ec_ctrl(EVP_PKEY_CTX *ctx, int type, int num, void *ptr)
         #ifdef WE_HAVE_ECDSA
             /* Keep a copy of the digest object. */
             case EVP_PKEY_CTRL_MD:
-                WOLFENGINE_MSG("received type: EVP_PKEY_CTRL_MD");
+                WOLFENGINE_MSG(WE_LOG_PK, "received type: EVP_PKEY_CTRL_MD");
                 ecc->md = (EVP_MD*)ptr;
                 break;
 
             /* Initialize digest. */
             case EVP_PKEY_CTRL_DIGESTINIT:
-                WOLFENGINE_MSG("received type: EVP_PKEY_CTRL_DIGEST");
+                WOLFENGINE_MSG(WE_LOG_PK,
+                               "received type: EVP_PKEY_CTRL_DIGEST");
                 break;
         #endif
 
         #ifdef WE_HAVE_ECKEYGEN
             /* Set the group to use. */
             case EVP_PKEY_CTRL_EC_PARAMGEN_CURVE_NID:
-                WOLFENGINE_MSG(
+                WOLFENGINE_MSG(WE_LOG_PK, 
                         "received type: EVP_PKEY_CTRL_EC_PARAMGEN_CURVE_NID");
                 ecc->curveName = num;
                 /* Get wolfSSL EC id from NID. */
@@ -960,7 +966,8 @@ static int we_ec_ctrl(EVP_PKEY_CTX *ctx, int type, int num, void *ptr)
         #ifdef WE_HAVE_ECDH
             /* Set the peer key (public key from peer). */
             case EVP_PKEY_CTRL_PEER_KEY:
-                WOLFENGINE_MSG("received type: EVP_PKEY_CTRL_PEER_KEY");
+                WOLFENGINE_MSG(WE_LOG_PK,
+                               "received type: EVP_PKEY_CTRL_PEER_KEY");
                 peerKey = (EVP_PKEY *)ptr;
                 /* Get the OpenSSL EC_KEY object. */
             #if OPENSSL_VERSION_NUMBER >= 0x30000000L
@@ -986,13 +993,13 @@ static int we_ec_ctrl(EVP_PKEY_CTX *ctx, int type, int num, void *ptr)
             default:
                 XSNPRINTF(errBuff, sizeof(errBuff), "Unsupported ctrl type %d",
                           type);
-                WOLFENGINE_ERROR_MSG(errBuff);
+                WOLFENGINE_ERROR_MSG(WE_LOG_PK, errBuff);
                 ret = 0;
                 break;
         }
     }
 
-    WOLFENGINE_LEAVE("we_ec_ctrl", ret);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_ec_ctrl", ret);
 
     return ret;
 }
@@ -1031,11 +1038,12 @@ int we_init_ecc_meths(void)
 {
     int ret = 1;
 
-    WOLFENGINE_ENTER("we_init_ecc_meths");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_init_ecc_meths");
 
     we_ec_method = EVP_PKEY_meth_new(EVP_PKEY_EC, 0);
     if (we_ec_method == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("EVP_PKEY_meth_new", we_ec_method);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK,
+                                   "EVP_PKEY_meth_new", we_ec_method);
         ret = 0;
     } else {
         EVP_PKEY_meth_set_init(we_ec_method, we_ec_init);
@@ -1061,7 +1069,8 @@ int we_init_ecc_meths(void)
     if (ret == 1) {
         we_ec_p192_method = EVP_PKEY_meth_new(EVP_PKEY_EC, 0);
         if (we_ec_p192_method == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("EVP_PKEY_meth_new", we_ec_p192_method);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "EVP_PKEY_meth_new",
+                                       we_ec_p192_method);
             ret = 0;
         } else {
             EVP_PKEY_meth_set_init(we_ec_p192_method, we_ec_p192_init);
@@ -1078,7 +1087,8 @@ int we_init_ecc_meths(void)
     if (ret == 1) {
         we_ec_p224_method = EVP_PKEY_meth_new(EVP_PKEY_EC, 0);
         if (we_ec_p224_method == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("EVP_PKEY_meth_new", we_ec_p224_method);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "EVP_PKEY_meth_new",
+                                       we_ec_p224_method);
             ret = 0;
         } else {
             EVP_PKEY_meth_set_init(we_ec_p224_method, we_ec_p224_init);
@@ -1095,7 +1105,8 @@ int we_init_ecc_meths(void)
     if (ret == 1) {
         we_ec_p256_method = EVP_PKEY_meth_new(EVP_PKEY_EC, 0);
         if (we_ec_p256_method == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("EVP_PKEY_meth_new", we_ec_p256_method);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "EVP_PKEY_meth_new",
+                                       we_ec_p256_method);
             ret = 0;
         } else {
             EVP_PKEY_meth_set_init(we_ec_p256_method, we_ec_p256_init);
@@ -1112,7 +1123,8 @@ int we_init_ecc_meths(void)
     if (ret == 1) {
         we_ec_p384_method = EVP_PKEY_meth_new(EVP_PKEY_EC, 0);
         if (we_ec_p384_method == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("EVP_PKEY_meth_new", we_ec_p384_method);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "EVP_PKEY_meth_new",
+                                       we_ec_p384_method);
             ret = 0;
         } else {
             EVP_PKEY_meth_set_init(we_ec_p384_method, we_ec_p384_init);
@@ -1129,7 +1141,8 @@ int we_init_ecc_meths(void)
     if (ret == 1) {
         we_ec_p521_method = EVP_PKEY_meth_new(EVP_PKEY_EC, 0);
         if (we_ec_p521_method == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("EVP_PKEY_meth_new", we_ec_p521_method);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "EVP_PKEY_meth_new",
+                                       we_ec_p521_method);
             ret = 0;
         } else {
             EVP_PKEY_meth_set_init(we_ec_p521_method, we_ec_p521_init);
@@ -1183,7 +1196,7 @@ int we_init_ecc_meths(void)
 #endif
     }
 
-    WOLFENGINE_LEAVE("we_init_ecc_meths", ret);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_init_ecc_meths", ret);
 
     return ret;
 }
@@ -1208,7 +1221,7 @@ static int we_ec_key_keygen(EC_KEY *key)
     ecc_key* pEcc = NULL;
     int len = 0;
 
-    WOLFENGINE_ENTER("we_ec_key_keygen");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_ec_key_keygen");
 
     /* Get the wolfSSL EC curve id for the group. */
     ret = we_ec_get_curve_id(EC_GROUP_get_curve_name(EC_KEY_get0_group(key)),
@@ -1216,14 +1229,15 @@ static int we_ec_key_keygen(EC_KEY *key)
     if (ret == 1) {
         len = wc_ecc_get_curve_size_from_id(curveId);
         if (len < 0) {
-            WOLFENGINE_ERROR_FUNC("wc_ecc_get_curve_size_from_id", len);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK,
+                                  "wc_ecc_get_curve_size_from_id", len);
             ret = 0;
 
         } else {
             /* Initialize a wolfSSL EC key object. */
             rc = wc_ecc_init(&ecc);
             if (rc != 0) {
-                WOLFENGINE_ERROR_FUNC("wc_ecc_init", rc);
+                WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_ecc_init", rc);
                 ret = 0;
             }
         }
@@ -1234,7 +1248,7 @@ static int we_ec_key_keygen(EC_KEY *key)
         /* Generate key. */
         rc = wc_ecc_make_key_ex(we_rng, len, &ecc, curveId);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_ecc_make_key_ex", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_ecc_make_key_ex", rc);
             ret = 0;
         }
     }
@@ -1245,7 +1259,7 @@ static int we_ec_key_keygen(EC_KEY *key)
 
     wc_ecc_free(pEcc);
 
-    WOLFENGINE_LEAVE("we_ec_key_keygen", ret);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_ec_key_keygen", ret);
 
     return ret;
 }
@@ -1274,7 +1288,7 @@ static int we_ec_key_compute_key(unsigned char **psec, size_t *pseclen,
     unsigned char* peerKey = NULL;
     unsigned char* secret = NULL;
 
-    WOLFENGINE_ENTER("we_ec_key_compute_key");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_ec_key_compute_key");
 
     /* Get wolfSSL curve id for EC group. */
     group = EC_KEY_get0_group(ecdh);
@@ -1288,7 +1302,8 @@ static int we_ec_key_compute_key(unsigned char **psec, size_t *pseclen,
     if (ret == 1) {
         rc = wc_ecc_get_curve_size_from_id(curveId);
         if (rc < 0) {
-            WOLFENGINE_ERROR_FUNC("wc_ecc_get_curve_size_from_id", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK,
+                                  "wc_ecc_get_curve_size_from_id", rc);
             ret = 0;
         } else {
             len = (word32)rc;
@@ -1302,7 +1317,7 @@ static int we_ec_key_compute_key(unsigned char **psec, size_t *pseclen,
         /* Initialize the wolfSSL private key object. */
         rc = wc_ecc_init(&key);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_ecc_init", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_ecc_init", rc);
             ret = 0;
         }
     }
@@ -1312,7 +1327,7 @@ static int we_ec_key_compute_key(unsigned char **psec, size_t *pseclen,
         /* Set RNG for side-channel resistant code. */
         rc = wc_ecc_set_rng(&key, we_rng);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_ecc_set_rng", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_ecc_set_rng", rc);
             ret = 0;
         }
     }
@@ -1327,7 +1342,7 @@ static int we_ec_key_compute_key(unsigned char **psec, size_t *pseclen,
         /* Initialize wolfSSL ECC key for peer's public key. */
         rc = wc_ecc_init(&peer);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_ecc_init", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_ecc_init", rc);
             ret = 0;
         }
     }
@@ -1340,7 +1355,7 @@ static int we_ec_key_compute_key(unsigned char **psec, size_t *pseclen,
         /* Import the public point into wolfSSL key object. */
         rc = wc_ecc_import_unsigned(pPeer, x, y, NULL, curveId);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_ecc_import_unsigned", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_ecc_import_unsigned", rc);
             ret = 0;
         }
     }
@@ -1348,7 +1363,7 @@ static int we_ec_key_compute_key(unsigned char **psec, size_t *pseclen,
         /* Calculate shared secret. */
         rc = wc_ecc_shared_secret(pKey, pPeer, secret, &len);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_ecc_shared_secret", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_ecc_shared_secret", rc);
             ret = 0;
         }
     }
@@ -1363,7 +1378,7 @@ static int we_ec_key_compute_key(unsigned char **psec, size_t *pseclen,
     wc_ecc_free(pPeer);
     wc_ecc_free(pKey);
 
-    WOLFENGINE_LEAVE("we_ec_key_compute_key", ret);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_ec_key_compute_key", ret);
 
     return ret;
 }
@@ -1393,7 +1408,7 @@ static int we_ec_key_sign(int type, const unsigned char *dgst, int dLen,
     int curveId;
     word32 outLen;
 
-    WOLFENGINE_ENTER("we_ec_key_sign");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_ec_key_sign");
 
     (void)type;
     (void)kinv;
@@ -1406,7 +1421,7 @@ static int we_ec_key_sign(int type, const unsigned char *dgst, int dLen,
         /* Initialize a wolfSSL key object. */
         rc = wc_ecc_init(&key);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("we_ecc_init", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "we_ecc_init", rc);
             ret = 0;
         }
     }
@@ -1426,7 +1441,7 @@ static int we_ec_key_sign(int type, const unsigned char *dgst, int dLen,
         outLen = *sigLen;
         rc = wc_ecc_sign_hash(dgst, dLen, sig, &outLen, we_rng, &key);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_ecc_sign_hash", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_ecc_sign_hash", rc);
             ret = 0;
         }
         if (ret == 1) {
@@ -1437,7 +1452,7 @@ static int we_ec_key_sign(int type, const unsigned char *dgst, int dLen,
 
     wc_ecc_free(pKey);
 
-    WOLFENGINE_LEAVE("we_ec_key_sign", ret);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_ec_key_sign", ret);
 
     return ret;
 }
@@ -1462,7 +1477,7 @@ static int we_ec_key_verify(int type, const unsigned char *dgst, int dLen,
     const EC_GROUP *group;
     int curveId;
 
-    WOLFENGINE_ENTER("we_ec_key_verify");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_ec_key_verify");
 
     (void)type;
 
@@ -1473,7 +1488,7 @@ static int we_ec_key_verify(int type, const unsigned char *dgst, int dLen,
         /* Initialize a wolfSSL key object. */
         rc = wc_ecc_init(&key);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_ecc_init", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_ecc_init", rc);
             ret = 0;
         }
     }
@@ -1487,7 +1502,7 @@ static int we_ec_key_verify(int type, const unsigned char *dgst, int dLen,
         /* Verify hash with wolfSSL. */
         rc = wc_ecc_verify_hash(sig, sigLen, dgst, dLen, &res, &key);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_ecc_verify_hash", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_ecc_verify_hash", rc);
             ret = 0;
         }
     }
@@ -1498,7 +1513,7 @@ static int we_ec_key_verify(int type, const unsigned char *dgst, int dLen,
 
     wc_ecc_free(pKey);
 
-    WOLFENGINE_LEAVE("we_ec_key_verify", ret);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_ec_key_verify", ret);
 
     return ret;
 }
@@ -1512,11 +1527,12 @@ int we_init_ec_key_meths(void)
 {
     int ret = 1;
 
-    WOLFENGINE_ENTER("we_init_ec_key_meths");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_init_ec_key_meths");
 
     we_ec_key_method = EC_KEY_METHOD_new(NULL);
     if (we_ec_key_method == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("EC_KEY_METHOD_new", we_ec_key_method);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK,
+                                   "EC_KEY_METHOD_new", we_ec_key_method);
         ret = 0;
     } else {
         EC_KEY_METHOD_set_keygen(we_ec_key_method, we_ec_key_keygen);
@@ -1525,7 +1541,7 @@ int we_init_ec_key_meths(void)
         EC_KEY_METHOD_set_verify(we_ec_key_method, we_ec_key_verify, NULL);
     }
 
-    WOLFENGINE_LEAVE("we_init_ec_key_meths", ret);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_init_ec_key_meths", ret);
 
     return ret;
 }

--- a/src/mac.c
+++ b/src/mac.c
@@ -73,17 +73,17 @@ static we_mac* we_mac_pkey_init(EVP_PKEY_CTX *ctx)
     int ret = 1;
     we_mac *mac = NULL;
 
-    WOLFENGINE_ENTER("we_mac_pkey_init");
+    WOLFENGINE_ENTER(WE_LOG_MAC, "we_mac_pkey_init");
 
     if (ctx == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("we_mac_pkey_init, ctx: ", ctx);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_MAC, "we_mac_pkey_init, ctx: ", ctx);
         ret = 0;
     }
 
     if (ret == 1) {
         mac = (we_mac *)OPENSSL_zalloc(sizeof(we_mac));
         if (mac == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("OPENSSL_zalloc", mac);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_MAC, "OPENSSL_zalloc", mac);
             ret = 0;
         }
     }
@@ -96,7 +96,7 @@ static we_mac* we_mac_pkey_init(EVP_PKEY_CTX *ctx)
         OPENSSL_free(mac);
         mac = NULL;
     }
-    WOLFENGINE_LEAVE("we_mac_pkey_init", ret);
+    WOLFENGINE_LEAVE(WE_LOG_MAC, "we_mac_pkey_init", ret);
 
     return mac;
 }
@@ -116,7 +116,8 @@ static int we_do_digest_init(EVP_PKEY_CTX *ctx, we_mac *mac)
     EVP_PKEY *pkey;
 
     if (mac == NULL) {
-        WOLFENGINE_ERROR_MSG("we_mac pointer is NULL in we_do_digest_init");
+        WOLFENGINE_ERROR_MSG(WE_LOG_MAC,
+                             "we_mac pointer is NULL in we_do_digest_init");
         ret = 0;
     }
 
@@ -163,7 +164,7 @@ static int we_do_digest_init(EVP_PKEY_CTX *ctx, we_mac *mac)
                 rc = wc_InitCmac(&mac->state.cmac, (const byte*)mac->key,
                     mac->keySz, WC_CMAC_AES, NULL);
                 if (rc != 0) {
-                    WOLFENGINE_ERROR_FUNC("wc_InitCmac", rc);
+                    WOLFENGINE_ERROR_FUNC(WE_LOG_MAC, "wc_InitCmac", rc);
                     ret = 0;
                 }
                 break;
@@ -172,13 +173,13 @@ static int we_do_digest_init(EVP_PKEY_CTX *ctx, we_mac *mac)
                 rc = wc_HmacSetKey(&mac->state.hmac, mac->type,
                     (const byte*)mac->key, (word32)mac->keySz);
                 if (rc != 0) {
-                    WOLFENGINE_ERROR_FUNC("wc_HmacSetKey", rc);
+                    WOLFENGINE_ERROR_FUNC(WE_LOG_MAC, "wc_HmacSetKey", rc);
                     ret = 0;
                 }
                 break;
 
             default:
-                WOLFENGINE_ERROR_MSG("Unknown mac algo found!");
+                WOLFENGINE_ERROR_MSG(WE_LOG_MAC, "Unknown mac algo found!");
                 ret = 0;
         }
     }
@@ -231,16 +232,17 @@ static int we_mac_pkey_ctrl(EVP_PKEY_CTX *ctx, int type, int num, void *ptr)
     int ret = 1;
     we_mac *mac = NULL;
 
-    WOLFENGINE_ENTER("we_mac_pkey_ctrl");
+    WOLFENGINE_ENTER(WE_LOG_MAC, "we_mac_pkey_ctrl");
     if (ctx == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("we_mac_pkey_ctrl", ctx);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_MAC, "we_mac_pkey_ctrl", ctx);
         ret = 0;
     }
 
     if (ret == 1) {
         mac = (we_mac *)EVP_PKEY_CTX_get_data(ctx);
         if (mac == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("EVP_PKEY_CTX_get_data", mac);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_MAC,
+                                       "EVP_PKEY_CTX_get_data", mac);
             ret = 0;
         }
     }
@@ -252,14 +254,16 @@ static int we_mac_pkey_ctrl(EVP_PKEY_CTX *ctx, int type, int num, void *ptr)
                 if (ptr != NULL && mac->algo == WE_HMAC_ALGO) {
                     mac->type = we_mac_md_to_hash_type((EVP_MD *)ptr);
                     if (mac->type < 0) {
-                        WOLFENGINE_ERROR_FUNC("we_mac_md_to_hash_type",
-                                mac->type);
+                        WOLFENGINE_ERROR_FUNC(WE_LOG_MAC,
+                                              "we_mac_md_to_hash_type",
+                                              mac->type);
                         ret = 0;
                     }
                     else {
                         mac->size = wc_HmacSizeByType(mac->type);
                         if (mac->size <= 0) {
-                            WOLFENGINE_ERROR_FUNC("wc_HmacSizeByType",
+                            WOLFENGINE_ERROR_FUNC(WE_LOG_MAC,
+                                                  "wc_HmacSizeByType",
                                                   mac->size);
                             ret = 0;
                         }
@@ -296,16 +300,16 @@ static int we_mac_pkey_ctrl(EVP_PKEY_CTX *ctx, int type, int num, void *ptr)
                 break;
 
             case WE_CTRL_DIGEST_INIT: /* handle digest init */
-                WOLFENGINE_MSG("Doing digest init from ctrl");
+                WOLFENGINE_MSG(WE_LOG_MAC, "Doing digest init from ctrl");
                 ret = we_do_digest_init(ctx, mac);
                 break;
 
             default:
-                WOLFENGINE_MSG("Unsupported HMAC ctrl encountered");
+                WOLFENGINE_MSG(WE_LOG_MAC, "Unsupported HMAC ctrl encountered");
                 ret = 0;
         }
     }
-    WOLFENGINE_LEAVE("we_mac_pkey_ctrl", ret);
+    WOLFENGINE_LEAVE(WE_LOG_MAC, "we_mac_pkey_ctrl", ret);
     return ret;
 }
 
@@ -325,9 +329,10 @@ static int we_mac_pkey_ctrl_str(EVP_PKEY_CTX *ctx, const char *type,
     (void)ctx;
     (void)type;
     (void)value;
-    WOLFENGINE_ENTER("we_mac_pkey_ctrl_str");
-    WOLFENGINE_ERROR_MSG("This function is currently a stub, was not used in test cases");
-    WOLFENGINE_LEAVE("we_mac_pkey_ctrl_str", ret);
+    WOLFENGINE_ENTER(WE_LOG_MAC, "we_mac_pkey_ctrl_str");
+    WOLFENGINE_ERROR_MSG(WE_LOG_MAC,
+            "This function is currently a stub, was not used in test cases");
+    WOLFENGINE_LEAVE(WE_LOG_MAC, "we_mac_pkey_ctrl_str", ret);
     return ret;
 }
 
@@ -345,17 +350,20 @@ static int we_mac_pkey_keygen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
     ASN1_OCTET_STRING *key;
     we_mac *mac;
 
-    WOLFENGINE_ENTER("we_mac_pkey_keygen");
+    WOLFENGINE_ENTER(WE_LOG_MAC, "we_mac_pkey_keygen");
     if (ctx == NULL || pkey == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("we_mac_pkey_keygen, ctx:  ", ctx);
-        WOLFENGINE_ERROR_FUNC_NULL("we_mac_pkey_keygen, pkey: ", pkey);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_MAC,
+                                   "we_mac_pkey_keygen, ctx:  ", ctx);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_MAC,
+                                   "we_mac_pkey_keygen, pkey: ", pkey);
         ret = 0;
     }
 
     if (ret == 1) {
         mac = (we_mac *)EVP_PKEY_CTX_get_data(ctx);
         if (mac == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("EVP_PKEY_CTX_get_data", mac);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_MAC,
+                                       "EVP_PKEY_CTX_get_data", mac);
             ret = 0;
         }
     }
@@ -380,7 +388,7 @@ static int we_mac_pkey_keygen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
         EVP_PKEY_assign(pkey, algo, key);
     }
 
-    WOLFENGINE_LEAVE("we_mac_pkey_keygen", ret);
+    WOLFENGINE_LEAVE(WE_LOG_MAC, "we_mac_pkey_keygen", ret);
     return ret;
 }
 
@@ -397,10 +405,12 @@ static int we_mac_pkey_signctx_init(EVP_PKEY_CTX *ctx, EVP_MD_CTX *mdCtx,
 {
     int ret = 1;
 
-    WOLFENGINE_ENTER("wc_mac_pkey_signctx_init");
+    WOLFENGINE_ENTER(WE_LOG_MAC, "wc_mac_pkey_signctx_init");
     if (ctx == NULL || mdCtx == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("we_mac_pkey_signctx_init, ctx: ", ctx);
-        WOLFENGINE_ERROR_FUNC_NULL("we_mac_pkey_signctx_init, data:", mdCtx);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_MAC,
+                                   "we_mac_pkey_signctx_init, ctx: ", ctx);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_MAC,
+                                   "we_mac_pkey_signctx_init, data:", mdCtx);
         ret = 0;
     }
 
@@ -413,7 +423,7 @@ static int we_mac_pkey_signctx_init(EVP_PKEY_CTX *ctx, EVP_MD_CTX *mdCtx,
         EVP_MD_CTX_set_update_fn(mdCtx, fn);
     }
 
-    WOLFENGINE_LEAVE("wc_mac_pkey_signctx_init", ret);
+    WOLFENGINE_LEAVE(WE_LOG_MAC, "wc_mac_pkey_signctx_init", ret);
     return ret;
 }
 
@@ -430,14 +440,14 @@ static we_mac* we_mac_copy(we_mac *src)
     we_mac *mac = NULL;
 
     if (src == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("we_mac_copy", src);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_MAC, "we_mac_copy", src);
         ret = 0;
     }
 
     if (ret == 1) {
         mac = (we_mac *)OPENSSL_zalloc(sizeof(we_mac));
         if (mac == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("OPENSSL_zalloc", mac);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_MAC, "OPENSSL_zalloc", mac);
             ret = 0;
         }
     }
@@ -546,7 +556,8 @@ static int wolfSSL_HmacCopy(Hmac* des, Hmac* src)
 #endif /* WOLFSSL_SHA3 */
 
         default:
-            WOLFENGINE_ERROR_MSG("Unknown/supported hash used with HMAC");
+            WOLFENGINE_ERROR_MSG(WE_LOG_MAC,
+                                 "Unknown/supported hash used with HMAC");
             return 0;
     }
 
@@ -613,15 +624,16 @@ static int we_mac_pkey_copy(EVP_PKEY_CTX *dst, EVP_PKEY_CTX *src)
     we_mac *dup;
 
     if (dst == NULL || src == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("we_mac_pkey_copy, dst: ", dst);
-        WOLFENGINE_ERROR_FUNC_NULL("we_mac_pkey_copy, src: ", src);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_MAC, "we_mac_pkey_copy, dst: ", dst);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_MAC, "we_mac_pkey_copy, src: ", src);
         ret = 0;
     }
 
     if (ret == 1) {
         mac = (we_mac *)EVP_PKEY_CTX_get_data(src);
         if (mac == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("EVP_PKEY_CTX_get_data", mac);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_MAC,
+                                       "EVP_PKEY_CTX_get_data", mac);
             ret = 0;
         }
     }
@@ -629,7 +641,7 @@ static int we_mac_pkey_copy(EVP_PKEY_CTX *dst, EVP_PKEY_CTX *src)
     if (ret == 1) {
         dup = we_mac_copy(mac);
         if (dup == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("we_mac_copy", dup);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_MAC, "we_mac_copy", dup);
             ret = 0;
         }
     }
@@ -649,12 +661,12 @@ static int we_mac_pkey_copy(EVP_PKEY_CTX *dst, EVP_PKEY_CTX *src)
         #endif
 
             default:
-                WOLFENGINE_ERROR_MSG("Unknown/supported MAC algo");
+                WOLFENGINE_ERROR_MSG(WE_LOG_MAC, "Unknown/supported MAC algo");
                 ret = 0;
         }
 
         if (ret != 1) {
-            WOLFENGINE_ERROR_FUNC("wolfSSL_*Copy", ret);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_MAC, "wolfSSL_*Copy", ret);
         }
     }
 
@@ -675,16 +687,18 @@ static void we_mac_pkey_cleanup(EVP_PKEY_CTX *ctx)
     int ret = 1;
     we_mac *mac;
 
-    WOLFENGINE_ENTER("we_mac_pkey_cleanup");
+    WOLFENGINE_ENTER(WE_LOG_MAC, "we_mac_pkey_cleanup");
     if (ctx == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("we_mac_pkey_cleanup, ctx: ", ctx);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_MAC,
+                                   "we_mac_pkey_cleanup, ctx: ", ctx);
         ret = 0;
     }
 
     if (ret == 1) {
         mac = (we_mac *)EVP_PKEY_CTX_get_data(ctx);
         if (mac == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("EVP_PKEY_CTX_get_data", mac);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_MAC,
+                                       "EVP_PKEY_CTX_get_data", mac);
             ret = 0;
         }
     }
@@ -710,7 +724,7 @@ static void we_mac_pkey_cleanup(EVP_PKEY_CTX *ctx)
         }
         OPENSSL_free(mac);
     }
-    WOLFENGINE_LEAVE("we_mac_pkey_cleanup", ret);
+    WOLFENGINE_LEAVE(WE_LOG_MAC, "we_mac_pkey_cleanup", ret);
     (void)ret;
 }
 
@@ -731,18 +745,18 @@ static int we_hmac_pkey_init(EVP_PKEY_CTX *ctx)
     int ret = 1, rc;
     we_mac *mac = NULL;
 
-    WOLFENGINE_ENTER("we_hmac_pkey_init");
+    WOLFENGINE_ENTER(WE_LOG_MAC, "we_hmac_pkey_init");
 
     mac = we_mac_pkey_init(ctx);
     if (mac == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("wc_mac_pkey_init", mac);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_MAC, "wc_mac_pkey_init", mac);
         ret = 0;
     }
 
     if (ret == 1) {
         rc = wc_HmacInit(&mac->state.hmac, NULL, INVALID_DEVID);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_HmacInit", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_MAC, "wc_HmacInit", rc);
             ret = 0;
         }
     }
@@ -751,7 +765,7 @@ static int we_hmac_pkey_init(EVP_PKEY_CTX *ctx)
         mac->algo = WE_HMAC_ALGO;
     }
 
-    WOLFENGINE_LEAVE("we_hmac_pkey_init", ret);
+    WOLFENGINE_LEAVE(WE_LOG_MAC, "we_hmac_pkey_init", ret);
     return ret;
 }
 
@@ -770,8 +784,10 @@ static int we_hmac_pkey_update(EVP_MD_CTX *ctx, const void *data, size_t dataSz)
     we_mac *mac;
 
     if (ctx == NULL || data == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("we_hmac_pkey_update, ctx: ", ctx);
-        WOLFENGINE_ERROR_FUNC_NULL("we_hmac_pkey_update, data:", (void*)data);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_MAC,
+                                   "we_hmac_pkey_update, ctx: ", ctx);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_MAC,
+                                   "we_hmac_pkey_update, data:", (void*)data);
         ret = 0;
     }
 
@@ -785,7 +801,8 @@ static int we_hmac_pkey_update(EVP_MD_CTX *ctx, const void *data, size_t dataSz)
         else {
             mac = (we_mac *)EVP_PKEY_CTX_get_data(pkeyCtx);
             if (mac == NULL) {
-                WOLFENGINE_ERROR_FUNC_NULL("EVP_PKEY_CTX_get_data", mac);
+                WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_MAC,
+                                           "EVP_PKEY_CTX_get_data", mac);
                 ret = 0;
             }
         }
@@ -794,7 +811,7 @@ static int we_hmac_pkey_update(EVP_MD_CTX *ctx, const void *data, size_t dataSz)
     if (ret == 1) {
         rc = wc_HmacUpdate(&mac->state.hmac, (const byte*)data, (word32)dataSz);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_HmacUpdate", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_MAC, "wc_HmacUpdate", rc);
             ret = 0;
         }
     }
@@ -831,25 +848,30 @@ static int we_hmac_pkey_signctx(EVP_PKEY_CTX *ctx, unsigned char *sig,
     int ret = 1, rc;
     we_mac *mac;
 
-    WOLFENGINE_ENTER("we_hmac_pkey_signctx");
+    WOLFENGINE_ENTER(WE_LOG_MAC, "we_hmac_pkey_signctx");
     if (ctx == NULL || siglen == NULL || mdCtx == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("we_hmac_pkey_signctx, ctx:    ", ctx);
-        WOLFENGINE_ERROR_FUNC_NULL("we_hmac_pkey_signctx, siglen: ", siglen);
-        WOLFENGINE_ERROR_FUNC_NULL("we_hmac_pkey_signctx, mdCtx:  ", mdCtx);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_MAC,
+                                   "we_hmac_pkey_signctx, ctx:    ", ctx);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_MAC,
+                                   "we_hmac_pkey_signctx, siglen: ", siglen);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_MAC,
+                                   "we_hmac_pkey_signctx, mdCtx:  ", mdCtx);
         ret = 0;
     }
 
     if (ret == 1) {
         mac = (we_mac *)EVP_PKEY_CTX_get_data(ctx);
         if (mac == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("EVP_PKEY_CTX_get_data", mac);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_MAC,
+                                       "EVP_PKEY_CTX_get_data", mac);
             ret = 0;
         }
     }
 
     if (ret == 1 && sig != NULL) {
         if (*siglen < (size_t)mac->size) {
-            WOLFENGINE_ERROR_MSG("MAC output buffer was too small");
+            WOLFENGINE_ERROR_MSG(WE_LOG_MAC,
+                                 "MAC output buffer was too small");
             ret = 0;
         }
     }
@@ -857,7 +879,7 @@ static int we_hmac_pkey_signctx(EVP_PKEY_CTX *ctx, unsigned char *sig,
     if (ret == 1 && sig != NULL) {
         rc = wc_HmacFinal(&mac->state.hmac, (byte*)sig);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_HmacFinal", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_MAC, "wc_HmacFinal", rc);
             ret = 0;
         }
     }
@@ -881,7 +903,8 @@ int we_init_hmac_pkey_meth(void)
 
     we_hmac_pkey_method = EVP_PKEY_meth_new(EVP_PKEY_HMAC, 0);
     if (we_hmac_pkey_method == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("EVP_PKEY_meth_new", we_hmac_pkey_method);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_MAC,
+                                   "EVP_PKEY_meth_new", we_hmac_pkey_method);
         ret = 0;
     }
 
@@ -929,8 +952,10 @@ static int we_cmac_pkey_update(EVP_MD_CTX *ctx, const void *data, size_t dataSz)
     we_mac *mac;
 
     if (ctx == NULL || data == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("we_cmac_pkey_update, ctx: ", ctx);
-        WOLFENGINE_ERROR_FUNC_NULL("we_cmac_pkey_update, data:", (void*)data);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_MAC,
+                                   "we_cmac_pkey_update, ctx: ", ctx);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_MAC,
+                                   "we_cmac_pkey_update, data:", (void*)data);
         ret = 0;
     }
 
@@ -944,7 +969,8 @@ static int we_cmac_pkey_update(EVP_MD_CTX *ctx, const void *data, size_t dataSz)
         else {
             mac = (we_mac *)EVP_PKEY_CTX_get_data(pkeyCtx);
             if (mac == NULL) {
-                WOLFENGINE_ERROR_FUNC_NULL("EVP_PKEY_CTX_get_data", mac);
+                WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_MAC,
+                                           "EVP_PKEY_CTX_get_data", mac);
                 ret = 0;
             }
         }
@@ -953,7 +979,7 @@ static int we_cmac_pkey_update(EVP_MD_CTX *ctx, const void *data, size_t dataSz)
     if (ret == 1) {
         rc = wc_CmacUpdate(&mac->state.cmac, (const byte*)data, (word32)dataSz);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_CmacUpdate", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_MAC, "wc_CmacUpdate", rc);
             ret = 0;
         }
     }
@@ -990,25 +1016,29 @@ static int we_cmac_pkey_signctx(EVP_PKEY_CTX *ctx, unsigned char *sig,
     int ret = 1, rc;
     we_mac *mac;
 
-    WOLFENGINE_ENTER("we_cmac_pkey_signctx");
+    WOLFENGINE_ENTER(WE_LOG_MAC, "we_cmac_pkey_signctx");
     if (ctx == NULL || siglen == NULL || mdCtx == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("we_cmac_pkey_signctx, ctx:    ", ctx);
-        WOLFENGINE_ERROR_FUNC_NULL("we_cmac_pkey_signctx, siglen: ", siglen);
-        WOLFENGINE_ERROR_FUNC_NULL("we_cmac_pkey_signctx, mdCtx:  ", mdCtx);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_MAC,
+                                   "we_cmac_pkey_signctx, ctx:    ", ctx);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_MAC,
+                                    "we_cmac_pkey_signctx, siglen: ", siglen);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_MAC,
+                                   "we_cmac_pkey_signctx, mdCtx:  ", mdCtx);
         ret = 0;
     }
 
     if (ret == 1) {
         mac = (we_mac *)EVP_PKEY_CTX_get_data(ctx);
         if (mac == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("EVP_PKEY_CTX_get_data", mac);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_MAC,
+                                       "EVP_PKEY_CTX_get_data", mac);
             ret = 0;
         }
     }
 
     if (ret == 1 && sig != NULL) {
         if (*siglen < WC_CMAC_TAG_MIN_SZ) {
-            WOLFENGINE_ERROR_MSG("MAC output buffer was too small");
+            WOLFENGINE_ERROR_MSG(WE_LOG_MAC, "MAC output buffer was too small");
             ret = 0;
         }
     }
@@ -1016,7 +1046,7 @@ static int we_cmac_pkey_signctx(EVP_PKEY_CTX *ctx, unsigned char *sig,
     if (ret == 1 && sig != NULL) {
         rc = wc_CmacFinal(&mac->state.cmac, (byte*)sig, (word32*)siglen);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_CmacFinal", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_MAC, "wc_CmacFinal", rc);
             ret = 0;
         }
     }
@@ -1026,7 +1056,7 @@ static int we_cmac_pkey_signctx(EVP_PKEY_CTX *ctx, unsigned char *sig,
         *siglen = WC_CMAC_TAG_MAX_SZ;
     }
 
-    WOLFENGINE_LEAVE("we_cmac_pkey_signctx", ret);
+    WOLFENGINE_LEAVE(WE_LOG_MAC, "we_cmac_pkey_signctx", ret);
     return ret;
 }
 
@@ -1042,11 +1072,11 @@ static int we_cmac_pkey_init(EVP_PKEY_CTX *ctx)
     int ret = 1;
     we_mac *mac = NULL;
 
-    WOLFENGINE_ENTER("we_cmac_pkey_init");
+    WOLFENGINE_ENTER(WE_LOG_MAC, "we_cmac_pkey_init");
 
     mac = we_mac_pkey_init(ctx);
     if (mac == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("wc_mac_pkey_init", mac);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_MAC, "wc_mac_pkey_init", mac);
         ret = 0;
     }
 
@@ -1054,7 +1084,7 @@ static int we_cmac_pkey_init(EVP_PKEY_CTX *ctx)
         mac->algo = WE_CMAC_ALGO;
     }
 
-    WOLFENGINE_LEAVE("we_cmac_pkey_init", ret);
+    WOLFENGINE_LEAVE(WE_LOG_MAC, "we_cmac_pkey_init", ret);
     return ret;
 }
 
@@ -1080,11 +1110,12 @@ int we_init_cmac_pkey_meth(void)
 {
     int ret = 1;
 
-    WOLFENGINE_ENTER("we_init_cmac_pkey_meth");
+    WOLFENGINE_ENTER(WE_LOG_MAC, "we_init_cmac_pkey_meth");
     we_cmac_pkey_method = EVP_PKEY_meth_new(EVP_PKEY_CMAC,
             EVP_PKEY_FLAG_SIGCTX_CUSTOM);
     if (we_cmac_pkey_method == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("EVP_PKEY_meth_new", we_cmac_pkey_method);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_MAC,
+                                   "EVP_PKEY_meth_new", we_cmac_pkey_method);
         ret = 0;
     }
 
@@ -1105,7 +1136,7 @@ int we_init_cmac_pkey_meth(void)
         we_cmac_pkey_method = NULL;
     }
 
-    WOLFENGINE_LEAVE("we_init_cmac_pkey_meth", ret);
+    WOLFENGINE_LEAVE(WE_LOG_MAC, "we_init_cmac_pkey_meth", ret);
     return ret;
 }
 
@@ -1128,7 +1159,7 @@ static void we_cmac_pkey_asn1_free(EVP_PKEY *pkey)
         ASN1_OCTET_STRING_free(key);
     #endif
     }
-    WOLFENGINE_LEAVE("we_cmac_pkey_asn1_free", ret);
+    WOLFENGINE_LEAVE(WE_LOG_MAC, "we_cmac_pkey_asn1_free", ret);
     (void)ret;
 }
 
@@ -1154,11 +1185,11 @@ int we_init_cmac_pkey_asn1_meth(void)
 {
     int ret = 1;
 
-    WOLFENGINE_ENTER("we_init_cmac_pkey_asn1_meth");
+    WOLFENGINE_ENTER(WE_LOG_MAC, "we_init_cmac_pkey_asn1_meth");
     we_cmac_pkey_asn1_method = EVP_PKEY_asn1_new(EVP_PKEY_CMAC, 0, "CMAC",
             "wolfSSL ASN1 CMAC method");
     if (we_cmac_pkey_asn1_method == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("EVP_PKEY_asn1_new",
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_MAC, "EVP_PKEY_asn1_new",
                 we_cmac_pkey_asn1_method);
         ret = 0;
     }
@@ -1180,7 +1211,7 @@ int we_init_cmac_pkey_asn1_meth(void)
         we_cmac_pkey_asn1_method = NULL;
     }
 
-    WOLFENGINE_LEAVE("we_init_cmac_pkey_asn1_meth", ret);
+    WOLFENGINE_LEAVE(WE_LOG_MAC, "we_init_cmac_pkey_asn1_meth", ret);
     return ret;
 }
 #endif /* WE_HAVE_CMAC */

--- a/src/random.c
+++ b/src/random.c
@@ -58,11 +58,11 @@ static int we_rand_mix_seed(unsigned char* buf, int num,
     int i;
     int j;
 
-    WOLFENGINE_ENTER("we_rand_mix_seed");
+    WOLFENGINE_ENTER(WE_LOG_RNG, "we_rand_mix_seed");
 
     rc = wc_InitSha256(&sha256);
     if (rc != 0) {
-        WOLFENGINE_ERROR_FUNC("wc_InitSha256", rc);
+        WOLFENGINE_ERROR_FUNC(WE_LOG_RNG, "wc_InitSha256", rc);
         ret = 0;
     }
     if (rc == 0) {
@@ -71,12 +71,12 @@ static int we_rand_mix_seed(unsigned char* buf, int num,
             /* Calculate hash of seed to save from hashing long data. */
             rc = wc_Sha256Update(&sha256, seed, seedLen);
             if (rc != 0) {
-                WOLFENGINE_ERROR_FUNC("wc_Sha256Update", rc);
+                WOLFENGINE_ERROR_FUNC(WE_LOG_RNG, "wc_Sha256Update", rc);
                 ret = 0;
             }
             rc = wc_Sha256Final(&sha256, seedHash);
             if (rc != 0) {
-                WOLFENGINE_ERROR_FUNC("wc_Sha256Final", rc);
+                WOLFENGINE_ERROR_FUNC(WE_LOG_RNG, "wc_Sha256Final", rc);
                 ret = 0;
             }
         }
@@ -95,18 +95,18 @@ static int we_rand_mix_seed(unsigned char* buf, int num,
             /* Calculate hash of seed hash and last hash. */
             rc = wc_Sha256Update(&sha256, seedHash, sizeof(seedHash));
             if (rc != 0) {
-                WOLFENGINE_ERROR_FUNC("wc_Sha256Update", rc);
+                WOLFENGINE_ERROR_FUNC(WE_LOG_RNG, "wc_Sha256Update", rc);
                 ret = 0;
             }
             rc = wc_Sha256Update(&sha256, hash, sizeof(hash));
             if (rc != 0) {
-                WOLFENGINE_ERROR_FUNC("wc_Sha256Update", rc);
+                WOLFENGINE_ERROR_FUNC(WE_LOG_RNG, "wc_Sha256Update", rc);
                 ret = 0;
             }
             /* Put hash into buffer to for next round. */
             rc = wc_Sha256Final(&sha256, hash);
             if (rc != 0) {
-               WOLFENGINE_ERROR_FUNC("wc_Sha256Final", rc);
+               WOLFENGINE_ERROR_FUNC(WE_LOG_RNG, "wc_Sha256Final", rc);
                ret = 0;
             }
             /* XOR this block into the random data. */
@@ -119,18 +119,18 @@ static int we_rand_mix_seed(unsigned char* buf, int num,
         if (seed == we_seed) {
             rc = wc_Sha256Update(&sha256, seedHash, sizeof(seedHash));
             if (rc != 0) {
-                WOLFENGINE_ERROR_FUNC("wc_Sha256Update", rc);
+                WOLFENGINE_ERROR_FUNC(WE_LOG_RNG, "wc_Sha256Update", rc);
                 ret = 0;
             }
             rc = wc_Sha256Update(&sha256, hash, sizeof(hash));
             if (rc != 0) {
-                WOLFENGINE_ERROR_FUNC("wc_Sha256Update", rc);
+                WOLFENGINE_ERROR_FUNC(WE_LOG_RNG, "wc_Sha256Update", rc);
                 ret = 0;
             }
             /* Put hash into global seed. */
             rc = wc_Sha256Final(&sha256, we_seed);
             if (rc != 0) {
-               WOLFENGINE_ERROR_FUNC("wc_Sha256Final", rc);
+               WOLFENGINE_ERROR_FUNC(WE_LOG_RNG, "wc_Sha256Final", rc);
                ret = 0;
             }
         }
@@ -138,7 +138,7 @@ static int we_rand_mix_seed(unsigned char* buf, int num,
         wc_Sha256Free(&sha256);
     }
 
-    WOLFENGINE_LEAVE("we_rand_mix_seed", ret);
+    WOLFENGINE_LEAVE(WE_LOG_RNG, "we_rand_mix_seed", ret);
 
     return ret;
 }
@@ -161,13 +161,13 @@ static int we_rand_seed(const void *buf, int num)
     int rc;
 #endif
 
-    WOLFENGINE_ENTER("we_rand_seed");
+    WOLFENGINE_ENTER(WE_LOG_RNG, "we_rand_seed");
 
 #ifndef WE_SINGLE_THREADED
     /* Lock for access to globals. */
     rc = wc_LockMutex(we_rng_mutex);
     if (rc != 0) {
-        WOLFENGINE_ERROR_FUNC("wc_LockMutex", rc);
+        WOLFENGINE_ERROR_FUNC(WE_LOG_RNG, "wc_LockMutex", rc);
         ret = 0;
     }
     else
@@ -177,7 +177,7 @@ static int we_rand_seed(const void *buf, int num)
         /* Add the seed to the underlying random number generator. */
         rc = wc_RNG_DRBG_Reseed(we_rng, buf, num);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_RNG_DRBG_Reseed", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_RNG, "wc_RNG_DRBG_Reseed", rc);
             ret = 0;
         }
 #else
@@ -190,7 +190,7 @@ static int we_rand_seed(const void *buf, int num)
     #endif
     }
 
-    WOLFENGINE_LEAVE("we_rand_seed", ret);
+    WOLFENGINE_LEAVE(WE_LOG_RNG, "we_rand_seed", ret);
 
     (void)ret;
 
@@ -223,13 +223,13 @@ static int we_rand_bytes(unsigned char *buf, int num)
     WC_RNG rng;
 #endif
 
-    WOLFENGINE_ENTER("we_rand_bytes");
+    WOLFENGINE_ENTER(WE_LOG_RNG, "we_rand_bytes");
 
 #ifdef WE_STATIC_WOLFSSL
     /* Generate true random using internal API. */
     rc = wc_GenerateSeed(&os, buf, num);
     if (rc != 0) {
-        WOLFENGINE_ERROR_FUNC("wc_GenerateSeed", rc);
+        WOLFENGINE_ERROR_FUNC(WE_LOG_RNG, "wc_GenerateSeed", rc);
         ret = 0;
     }
 
@@ -237,28 +237,28 @@ static int we_rand_bytes(unsigned char *buf, int num)
     /* Create a new random number generator that is seeded with true random. */
     rc = wc_InitRng(&rng);
     if (rc != 0) {
-        WOLFENGINE_ERROR_FUNC("wc_InitRng", rc);
+        WOLFENGINE_ERROR_FUNC(WE_LOG_RNG, "wc_InitRng", rc);
         ret = 0;
     }
     else {
         /* Generate true random. */
         rc = wc_RNG_GenerateBlock(&rng, buf, num);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_RNG_GenerateBlock", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_RNG, "wc_RNG_GenerateBlock", rc);
             ret = 0;
         }
 
         /* Dispose of random number generator. */
         rc = wc_FreeRng(&rng);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_FreeRng", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_RNG, "wc_FreeRng", rc);
             ret = 0;
         }
     }
 
 #endif
 
-    WOLFENGINE_LEAVE("we_rand_bytes", ret);
+    WOLFENGINE_LEAVE(WE_LOG_RNG, "we_rand_bytes", ret);
 
     return ret;
 }
@@ -267,8 +267,8 @@ static int we_rand_bytes(unsigned char *buf, int num)
 static void we_rand_cleanup(void)
 {
     /* Global random cleanup done in internal.c: we_final_random(). */
-    WOLFENGINE_ENTER("we_rand_cleanup");
-    WOLFENGINE_LEAVE("we_rand_cleanup", 0);
+    WOLFENGINE_ENTER(WE_LOG_RNG, "we_rand_cleanup");
+    WOLFENGINE_LEAVE(WE_LOG_RNG, "we_rand_cleanup", 0);
 }
 
 /**
@@ -286,7 +286,7 @@ static int we_rand_add(const void *buf, int num, double entropy)
 {
     int ret;
 
-    WOLFENGINE_ENTER("we_rand_add");
+    WOLFENGINE_ENTER(WE_LOG_RNG, "we_rand_add");
 
     /* Call seed implementation - entropy not used. */
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
@@ -297,7 +297,7 @@ static int we_rand_add(const void *buf, int num, double entropy)
 #endif
     (void)entropy;
 
-    WOLFENGINE_LEAVE("we_rand_add", ret);
+    WOLFENGINE_LEAVE(WE_LOG_RNG, "we_rand_add", ret);
     (void)ret;
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
@@ -317,12 +317,12 @@ static int we_rand_pseudorand(unsigned char *buf, int num)
     int ret = 1;
     int rc;
 
-    WOLFENGINE_ENTER("we_rand_pseudorand");
+    WOLFENGINE_ENTER(WE_LOG_RNG, "we_rand_pseudorand");
 
 #ifndef WE_SINGLE_THREADED
     rc = wc_LockMutex(we_rng_mutex);
     if (rc != 0) {
-        WOLFENGINE_ERROR_FUNC("wc_LockMutex", rc);
+        WOLFENGINE_ERROR_FUNC(WE_LOG_RNG, "wc_LockMutex", rc);
     }
     else
 #endif
@@ -330,7 +330,7 @@ static int we_rand_pseudorand(unsigned char *buf, int num)
         /* Use global random to generator pseudo-random data. */
         rc = wc_RNG_GenerateBlock(we_rng, buf, num);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_RNG_GenerateBlock", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_RNG, "wc_RNG_GenerateBlock", rc);
             ret = 0;
         }
     #ifndef WE_STATIC_WOLFSSL
@@ -344,7 +344,7 @@ static int we_rand_pseudorand(unsigned char *buf, int num)
     #endif
     }
 
-    WOLFENGINE_LEAVE("we_rand_pseudorand", ret);
+    WOLFENGINE_LEAVE(WE_LOG_RNG, "we_rand_pseudorand", ret);
 
     return ret;
 }
@@ -356,8 +356,8 @@ static int we_rand_pseudorand(unsigned char *buf, int num)
  */
 static int we_rand_status(void)
 {
-    WOLFENGINE_ENTER("we_rand_status");
-    WOLFENGINE_LEAVE("we_rand_status", 1);
+    WOLFENGINE_ENTER(WE_LOG_RNG, "we_rand_status");
+    WOLFENGINE_LEAVE(WE_LOG_RNG, "we_rand_status", 1);
 
     /* Always have enough entropy. */
     return 1;

--- a/src/rsa.c
+++ b/src/rsa.c
@@ -74,11 +74,11 @@ static int we_set_public_key(RSA *rsaKey, we_Rsa *engineRsa)
     int pubDerLen = 0;
     word32 idx = 0;
 
-    WOLFENGINE_ENTER("we_set_public_key");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_set_public_key");
 
     pubDerLen = i2d_RSAPublicKey(rsaKey, &pubDer);
     if (pubDerLen == 0) {
-        WOLFENGINE_ERROR_FUNC("i2d_RSAPublicKey", pubDerLen);
+        WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "i2d_RSAPublicKey", pubDerLen);
         ret = 0;
     }
 
@@ -86,7 +86,7 @@ static int we_set_public_key(RSA *rsaKey, we_Rsa *engineRsa)
         rc = wc_RsaPublicKeyDecode(pubDer, &idx, &engineRsa->key,
                                    pubDerLen);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_RsaPublicKeyDecode", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_RsaPublicKeyDecode", rc);
             ret = 0;
         }
     }
@@ -99,7 +99,7 @@ static int we_set_public_key(RSA *rsaKey, we_Rsa *engineRsa)
         OPENSSL_free(pubDer);
     }
 
-    WOLFENGINE_LEAVE("we_set_public_key", ret);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_set_public_key", ret);
 
     return ret;
 }
@@ -119,11 +119,11 @@ static int we_set_private_key(RSA *rsaKey, we_Rsa *engineRsa)
     int privDerLen = 0;
     word32 idx = 0;
 
-    WOLFENGINE_ENTER("we_set_private_key");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_set_private_key");
 
     privDerLen = i2d_RSAPrivateKey(rsaKey, &privDer);
     if (privDerLen == 0) {
-        WOLFENGINE_ERROR_FUNC("i2d_RSAPrivateKey", privDerLen);
+        WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "i2d_RSAPrivateKey", privDerLen);
         ret = 0;
     }
 
@@ -131,7 +131,7 @@ static int we_set_private_key(RSA *rsaKey, we_Rsa *engineRsa)
         rc = wc_RsaPrivateKeyDecode(privDer, &idx, &engineRsa->key,
                                     privDerLen);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_RsaPrivateKeyDecode", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_RsaPrivateKeyDecode", rc);
             ret = 0;
         }
     }
@@ -144,7 +144,7 @@ static int we_set_private_key(RSA *rsaKey, we_Rsa *engineRsa)
         OPENSSL_clear_free(privDer, privDerLen);
     }
 
-    WOLFENGINE_LEAVE("we_set_private_key", ret);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_set_private_key", ret);
 
     return ret;
 }
@@ -161,18 +161,18 @@ static int we_rsa_init(RSA *rsa)
     int rc = 0;
     we_Rsa *engineRsa;
 
-    WOLFENGINE_ENTER("we_rsa_init");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_rsa_init");
 
     engineRsa = (we_Rsa *)OPENSSL_zalloc(sizeof(we_Rsa));
     if (engineRsa == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("OPENSSL_zalloc", engineRsa);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "OPENSSL_zalloc", engineRsa);
         ret = 0;
     }
 
     if (ret == 1) {
         rc = wc_InitRsaKey(&engineRsa->key, NULL);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_InitRsaKey", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_InitRsaKey", rc);
             ret = 0;
         }
     }
@@ -181,7 +181,7 @@ static int we_rsa_init(RSA *rsa)
     if (ret == 1) {
         rc = wc_RsaSetRNG(&engineRsa->key, we_rng);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_RsaSetRNG", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_RsaSetRNG", rc);
             ret = 0;
         }
     }
@@ -190,7 +190,7 @@ static int we_rsa_init(RSA *rsa)
     if (ret == 1) {
         rc = RSA_set_app_data(rsa, engineRsa);
         if (rc != 1) {
-            WOLFENGINE_ERROR_FUNC("RSA_set_app_data", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "RSA_set_app_data", rc);
             ret = 0;
         }
     }
@@ -213,7 +213,7 @@ static int we_rsa_finish(RSA *rsa)
 {
     we_Rsa *engineRsa;
 
-    WOLFENGINE_ENTER("we_rsa_finish");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_rsa_finish");
 
     engineRsa = RSA_get_app_data(rsa);
     if (engineRsa != NULL) {
@@ -222,7 +222,7 @@ static int we_rsa_finish(RSA *rsa)
         RSA_set_app_data(rsa, NULL);
     }
 
-    WOLFENGINE_LEAVE("we_rsa_finish", 1);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_rsa_finish", 1);
 
     return 1;
 }
@@ -244,18 +244,18 @@ static int we_rsa_pub_enc(int fromLen, const unsigned char *from,
     int rc = 0;
     we_Rsa *engineRsa = NULL;
 
-    WOLFENGINE_ENTER("we_rsa_pub_enc");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_rsa_pub_enc");
 
     engineRsa = (we_Rsa *)RSA_get_app_data(rsa);
     if (engineRsa == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("RSA_get_app_data", engineRsa);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "RSA_get_app_data", engineRsa);
         ret = -1;
     }
 
     if (ret == 1 && !engineRsa->pubKeySet) {
         rc = we_set_public_key(rsa, engineRsa);
         if (rc == 0) {
-            WOLFENGINE_ERROR_FUNC("we_set_public_key", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "we_set_public_key", rc);
             ret = -1;
         }
     }
@@ -267,7 +267,7 @@ static int we_rsa_pub_enc(int fromLen, const unsigned char *from,
                 rc = wc_RsaPublicEncrypt(from, fromLen, to, RSA_size(rsa),
                                          &engineRsa->key, we_rng);
                 if (rc < 0) {
-                    WOLFENGINE_ERROR_FUNC("wc_RsaPublicEncrypt", rc);
+                    WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_RsaPublicEncrypt", rc);
                     ret = -1;
                 }
                 else {
@@ -281,7 +281,8 @@ static int we_rsa_pub_enc(int fromLen, const unsigned char *from,
                                             WC_RSA_OAEP_PAD, WC_HASH_TYPE_SHA,
                                             WC_MGF1SHA1, NULL, 0);
                 if (rc < 0) {
-                    WOLFENGINE_ERROR_FUNC("wc_RsaPublicEncrypt_ex", rc);
+                    WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_RsaPublicEncrypt_ex",
+                                          rc);
                     ret = -1;
                 }
                 else {
@@ -294,7 +295,8 @@ static int we_rsa_pub_enc(int fromLen, const unsigned char *from,
                                             WC_RSA_NO_PAD, WC_HASH_TYPE_NONE, 0,
                                             NULL, 0);
                 if (rc < 0) {
-                    WOLFENGINE_ERROR_FUNC("wc_RsaPublicEncrypt_ex", rc);
+                    WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_RsaPublicEncrypt_ex",
+                                          rc);
                     ret = -1;
                 }
                 else {
@@ -302,12 +304,13 @@ static int we_rsa_pub_enc(int fromLen, const unsigned char *from,
                 }
                 break;
             default:
-                WOLFENGINE_ERROR_MSG("we_rsa_pub_enc: unknown padding");
+                WOLFENGINE_ERROR_MSG(WE_LOG_PK,
+                                     "we_rsa_pub_enc: unknown padding");
                 ret = -1;
         }
     }
 
-    WOLFENGINE_LEAVE("we_rsa_pub_enc", ret);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_rsa_pub_enc", ret);
 
     return ret;
 }
@@ -329,18 +332,18 @@ static int we_rsa_priv_dec(int fromLen, const unsigned char *from,
     int rc = 0;
     we_Rsa *engineRsa = NULL;
 
-    WOLFENGINE_ENTER("we_rsa_priv_dec");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_rsa_priv_dec");
 
     engineRsa = (we_Rsa *)RSA_get_app_data(rsa);
     if (engineRsa == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("RSA_get_app_data", engineRsa);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "RSA_get_app_data", engineRsa);
         ret = -1;
     }
 
     if (ret == 1 && !engineRsa->privKeySet) {
         rc = we_set_private_key(rsa, engineRsa);
         if (rc == 0) {
-            WOLFENGINE_ERROR_FUNC("we_set_private_key", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "we_set_private_key", rc);
             ret = -1;
         }
     }
@@ -352,7 +355,8 @@ static int we_rsa_priv_dec(int fromLen, const unsigned char *from,
                 rc = wc_RsaPrivateDecrypt(from, fromLen, to, RSA_size(rsa),
                                           &engineRsa->key);
                 if (rc < 0) {
-                    WOLFENGINE_ERROR_FUNC("wc_RsaPrivateDecrypt", rc);
+                    WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_RsaPrivateDecrypt",
+                                          rc);
                     ret = -1;
                 }
                 else {
@@ -366,7 +370,8 @@ static int we_rsa_priv_dec(int fromLen, const unsigned char *from,
                                              WC_HASH_TYPE_SHA, WC_MGF1SHA1,
                                              NULL, 0);
                 if (rc < 0) {
-                    WOLFENGINE_ERROR_FUNC("wc_RsaPrivateDecrypt_ex", rc);
+                    WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_RsaPrivateDecrypt_ex",
+                                          rc);
                     ret = -1;
                 }
                 else {
@@ -378,7 +383,8 @@ static int we_rsa_priv_dec(int fromLen, const unsigned char *from,
                                              &engineRsa->key, WC_RSA_NO_PAD,
                                              WC_HASH_TYPE_NONE, 0, NULL, 0);
                 if (rc < 0) {
-                    WOLFENGINE_ERROR_FUNC("wc_RsaPrivateDecrypt_ex", rc);
+                    WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_RsaPrivateDecrypt_ex",
+                                          rc);
                     ret = -1;
                 }
                 else {
@@ -386,12 +392,13 @@ static int we_rsa_priv_dec(int fromLen, const unsigned char *from,
                 }
                 break;
             default:
-                WOLFENGINE_ERROR_MSG("we_rsa_priv_dec: unknown padding");
+                WOLFENGINE_ERROR_MSG(WE_LOG_PK,
+                                     "we_rsa_priv_dec: unknown padding");
                 ret = -1;
         }
     }
 
-    WOLFENGINE_LEAVE("we_rsa_priv_dec", ret);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_rsa_priv_dec", ret);
 
     return ret;
 }
@@ -449,14 +456,14 @@ static int we_rsa_priv_enc_int(size_t fromLen, const unsigned char *from,
     unsigned int tLen = (unsigned int)toLen;
     const EVP_MD *mdMGF1;
 
-    WOLFENGINE_ENTER("we_rsa_priv_enc_int");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_rsa_priv_enc_int");
 
     switch (rsa->padMode) {
         case RSA_PKCS1_PADDING:
             /* PKCS 1 v1.5 padding using block type 1. */
             rc = wc_RsaSSL_Sign(from, fromLen, to, toLen, &rsa->key, we_rng);
             if (rc < 0) {
-                WOLFENGINE_ERROR_FUNC("wc_RsaSSL_Sign", rc);
+                WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_RsaSSL_Sign", rc);
                 ret = -1;
             }
             else {
@@ -467,7 +474,7 @@ static int we_rsa_priv_enc_int(size_t fromLen, const unsigned char *from,
             rc = wc_RsaDirect((byte*)from, (unsigned int)fromLen, to, &tLen,
                               &rsa->key, RSA_PRIVATE_ENCRYPT, we_rng);
             if (rc < 0) {
-                WOLFENGINE_ERROR_FUNC("wc_RsaDirect", rc);
+                WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_RsaDirect", rc);
                 ret = -1;
             }
             else {
@@ -482,7 +489,7 @@ static int we_rsa_priv_enc_int(size_t fromLen, const unsigned char *from,
                 we_mgf_from_hash(EVP_MD_type(mdMGF1)), rsa->saltLen,
                 &rsa->key, we_rng);
             if (rc < 0) {
-                WOLFENGINE_ERROR_FUNC("wc_RsaPSS_Sign_ex", rc);
+                WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_RsaPSS_Sign_ex", rc);
                 ret = -1;
             }
             else {
@@ -490,11 +497,12 @@ static int we_rsa_priv_enc_int(size_t fromLen, const unsigned char *from,
             }
             break;
         default:
-            WOLFENGINE_ERROR_MSG("we_rsa_priv_enc_int: unknown padding");
+            WOLFENGINE_ERROR_MSG(WE_LOG_PK,
+                                 "we_rsa_priv_enc_int: unknown padding");
             ret = -1;
     }
 
-    WOLFENGINE_LEAVE("we_rsa_priv_enc_int", ret);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_rsa_priv_enc_int", ret);
 
     return ret;
 }
@@ -516,18 +524,18 @@ static int we_rsa_priv_enc(int fromLen, const unsigned char *from,
     int rc = 0;
     we_Rsa *engineRsa = NULL;
 
-    WOLFENGINE_ENTER("we_rsa_priv_enc");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_rsa_priv_enc");
 
     engineRsa = (we_Rsa *)RSA_get_app_data(rsa);
     if (engineRsa == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("RSA_get_app_data", engineRsa);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "RSA_get_app_data", engineRsa);
         ret = -1;
     }
 
     if (ret == 1 && !engineRsa->pubKeySet) {
         rc = we_set_public_key(rsa, engineRsa);
         if (rc == 0) {
-            WOLFENGINE_ERROR_FUNC("we_set_public_key", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "we_set_public_key", rc);
             ret = -1;
         }
     }
@@ -536,11 +544,11 @@ static int we_rsa_priv_enc(int fromLen, const unsigned char *from,
         engineRsa->padMode = padding;
         ret = we_rsa_priv_enc_int(fromLen, from, RSA_size(rsa), to, engineRsa);
         if (ret == -1) {
-            WOLFENGINE_ERROR_FUNC("we_rsa_priv_enc_int", ret);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "we_rsa_priv_enc_int", ret);
         }
     }
 
-    WOLFENGINE_LEAVE("we_rsa_priv_enc", ret);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_rsa_priv_enc", ret);
 
     return ret;
 }
@@ -564,14 +572,14 @@ static int we_rsa_pub_dec_int(size_t fromLen, const unsigned char *from,
     unsigned int tLen = (unsigned int)toLen;
     const EVP_MD *mdMGF1;
 
-    WOLFENGINE_ENTER("we_rsa_pub_dec_int");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_rsa_pub_dec_int");
 
     switch (rsa->padMode) {
         case RSA_PKCS1_PADDING:
             /* PKCS #1 v1.5 padding using block type 1. */
             rc = wc_RsaSSL_Verify(from, fromLen, to, toLen, &rsa->key);
             if (rc < 0) {
-                WOLFENGINE_ERROR_FUNC("wc_RsaSSL_Verify", rc);
+                WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_RsaSSL_Verify", rc);
                 ret = -1;
             }
             else {
@@ -582,7 +590,7 @@ static int we_rsa_pub_dec_int(size_t fromLen, const unsigned char *from,
             rc = wc_RsaDirect((byte*)from, (unsigned int)fromLen, to, &tLen,
                               &rsa->key, RSA_PUBLIC_DECRYPT, we_rng);
             if (rc < 0) {
-                WOLFENGINE_ERROR_FUNC("wc_RsaDirect", rc);
+                WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_RsaDirect", rc);
                 ret = -1;
             }
             else {
@@ -597,18 +605,19 @@ static int we_rsa_pub_dec_int(size_t fromLen, const unsigned char *from,
                 we_mgf_from_hash(EVP_MD_type(mdMGF1)), rsa->saltLen,
                 &rsa->key);
             if (rc < 0) {
-                WOLFENGINE_ERROR_FUNC("wc_RsaPSS_Verify_ex", rc);
+                WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_RsaPSS_Verify_ex", rc);
                 ret = -1;
             } else {
                 ret = rc;
             }
             break;
         default:
-            WOLFENGINE_ERROR_MSG("we_rsa_pub_dec_int: unknown padding");
+            WOLFENGINE_ERROR_MSG(WE_LOG_PK,
+                                 "we_rsa_pub_dec_int: unknown padding");
             ret = -1;
     }
 
-    WOLFENGINE_LEAVE("we_rsa_pub_dec_int", ret);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_rsa_pub_dec_int", ret);
 
     return ret;
 }
@@ -630,18 +639,18 @@ static int we_rsa_pub_dec(int fromLen, const unsigned char *from,
     int rc = 0;
     we_Rsa *engineRsa = NULL;
 
-    WOLFENGINE_ENTER("we_rsa_pub_dec");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_rsa_pub_dec");
 
     engineRsa = (we_Rsa *)RSA_get_app_data(rsa);
     if (engineRsa == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("RSA_get_app_data", engineRsa);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "RSA_get_app_data", engineRsa);
         ret = -1;
     }
 
     if (ret == 1 && !engineRsa->pubKeySet) {
         rc = we_set_public_key(rsa, engineRsa);
         if (rc == 0) {
-            WOLFENGINE_ERROR_FUNC("we_set_public_key", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "we_set_public_key", rc);
             ret = -1;
         }
     }
@@ -650,11 +659,11 @@ static int we_rsa_pub_dec(int fromLen, const unsigned char *from,
         engineRsa->padMode = padding;
         ret = we_rsa_pub_dec_int(fromLen, from, RSA_size(rsa), to, engineRsa);
         if (ret == -1) {
-            WOLFENGINE_ERROR_FUNC("we_rsa_pub_dec_int", ret);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "we_rsa_pub_dec_int", ret);
         }
     }
 
-    WOLFENGINE_LEAVE("we_rsa_pub_dec", ret);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_rsa_pub_dec", ret);
 
     return ret;
 }
@@ -672,18 +681,18 @@ static int we_convert_rsa(RsaKey *wolfKey, RSA *osslKey)
     BIGNUM *eDup = NULL, *nDup = NULL, *dDup = NULL, *pDup = NULL, *qDup = NULL,
            *dmp1Dup = NULL, *dmq1Dup = NULL, *iqmpDup = NULL;
 
-    WOLFENGINE_ENTER("we_convert_rsa");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_convert_rsa");
 
     derLen = wc_RsaKeyToDer(wolfKey, NULL, 0);
     if (derLen <= 0) {
-        WOLFENGINE_ERROR_FUNC("wc_RsaKeyToDer", derLen);
+        WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_RsaKeyToDer", derLen);
         ret = 0;
     }
 
     if (ret == 1) {
         der = (unsigned char *)OPENSSL_malloc(derLen);
         if (der == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("OPENSSL_malloc", der);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "OPENSSL_malloc", der);
             ret = 0;
         }
     }
@@ -691,7 +700,7 @@ static int we_convert_rsa(RsaKey *wolfKey, RSA *osslKey)
     if (ret == 1) {
         derLen = wc_RsaKeyToDer(wolfKey, der, derLen);
         if (derLen <= 0) {
-            WOLFENGINE_ERROR_FUNC("wc_RsaKeyToDer", derLen);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_RsaKeyToDer", derLen);
             ret = 0;
         }
     }
@@ -705,7 +714,8 @@ static int we_convert_rsa(RsaKey *wolfKey, RSA *osslKey)
         derPtr = (const unsigned char *)der;
         decodedRsa = d2i_RSAPrivateKey(NULL, &derPtr, derLen);
         if (decodedRsa == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("d2i_RSAPrivateKey", decodedRsa);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "d2i_RSAPrivateKey",
+                                       decodedRsa);
             ret = 0;
         }
     }
@@ -719,56 +729,56 @@ static int we_convert_rsa(RsaKey *wolfKey, RSA *osslKey)
     if (ret == 1) {
         eDup = BN_dup(e);
         if (eDup == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("BN_dup", eDup);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "BN_dup", eDup);
             ret = 0;
         }
     }
     if (ret == 1) {
         nDup = BN_dup(n);
         if (nDup == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("BN_dup", nDup);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "BN_dup", nDup);
             ret = 0;
         }
     }
     if (ret == 1) {
         dDup = BN_dup(d);
         if (dDup == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("BN_dup", dDup);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "BN_dup", dDup);
             ret = 0;
         }
     }
     if (ret == 1) {
         pDup = BN_dup(p);
         if (pDup == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("BN_dup", pDup);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "BN_dup", pDup);
             ret = 0;
         }
     }
     if (ret == 1) {
         qDup = BN_dup(q);
         if (qDup == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("BN_dup", qDup);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "BN_dup", qDup);
             ret = 0;
         }
     }
     if (ret == 1) {
         dmp1Dup = BN_dup(dmp1);
         if (dmp1Dup == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("BN_dup", dmp1Dup);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "BN_dup", dmp1Dup);
             ret = 0;
         }
     }
     if (ret == 1) {
         dmq1Dup = BN_dup(dmq1);
         if (dmq1Dup == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("BN_dup", dmq1Dup);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "BN_dup", dmq1Dup);
             ret = 0;
         }
     }
     if (ret == 1) {
         iqmpDup = BN_dup(iqmp);
         if (iqmpDup == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("BN_dup", iqmpDup);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "BN_dup", iqmpDup);
             ret = 0;
         }
     }
@@ -776,21 +786,21 @@ static int we_convert_rsa(RsaKey *wolfKey, RSA *osslKey)
     if (ret == 1) {
         rc = RSA_set0_key(osslKey, nDup, eDup, dDup);
         if (rc != 1) {
-            WOLFENGINE_ERROR_FUNC("RSA_set0_key", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "RSA_set0_key", rc);
             ret = 0;
         }
     }
     if (ret == 1) {
         rc = RSA_set0_factors(osslKey, pDup, qDup);
         if (rc != 1) {
-            WOLFENGINE_ERROR_FUNC("RSA_set0_factors", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "RSA_set0_factors", rc);
             ret = 0;
         }
     }
     if (ret == 1) {
         rc = RSA_set0_crt_params(osslKey, dmp1Dup, dmq1Dup, iqmpDup);
         if (rc != 1) {
-            WOLFENGINE_ERROR_FUNC("RSA_set0_crt_params", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "RSA_set0_crt_params", rc);
             ret = 0;
         }
     }
@@ -802,7 +812,7 @@ static int we_convert_rsa(RsaKey *wolfKey, RSA *osslKey)
         RSA_free(decodedRsa);
     }
 
-    WOLFENGINE_LEAVE("we_convert_rsa", ret);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_convert_rsa", ret);
 
     return ret;
 }
@@ -812,21 +822,21 @@ static int we_rsa_keygen_int(RsaKey *wolfKey, RSA **osslKey, int bits, long e)
     int ret = 1;
     int rc = 0;
 
-    WOLFENGINE_ENTER("we_rsa_pkey_keygen");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_rsa_pkey_keygen");
 
     if (wolfKey == NULL) {
-        WOLFENGINE_ERROR_MSG("we_rsa_keygen_int: wolfKey NULL");
+        WOLFENGINE_ERROR_MSG(WE_LOG_PK, "we_rsa_keygen_int: wolfKey NULL");
         ret = 0;
     }
     if (osslKey == NULL) {
-        WOLFENGINE_ERROR_MSG("we_rsa_keygen_int: osslKey NULL");
+        WOLFENGINE_ERROR_MSG(WE_LOG_PK, "we_rsa_keygen_int: osslKey NULL");
         ret = 0;
     }
 
     if (ret == 1) {
         rc = wc_MakeRsaKey(wolfKey, bits, e, we_rng);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_MakeRsaKey", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_MakeRsaKey", rc);
             ret = 0;
         }
     }
@@ -834,7 +844,7 @@ static int we_rsa_keygen_int(RsaKey *wolfKey, RSA **osslKey, int bits, long e)
     if (ret == 1 && *osslKey == NULL) {
         *osslKey = RSA_new();
         if (*osslKey == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("RSA_new", *osslKey);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "RSA_new", *osslKey);
             ret = 0;
         }
     }
@@ -842,12 +852,12 @@ static int we_rsa_keygen_int(RsaKey *wolfKey, RSA **osslKey, int bits, long e)
     if (ret == 1) {
         rc = we_convert_rsa(wolfKey, *osslKey);
         if (rc != 1) {
-            WOLFENGINE_ERROR_FUNC("we_convert_rsa", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "we_convert_rsa", rc);
             ret = 0;
         }
     }
 
-    WOLFENGINE_LEAVE("we_rsa_keygen_int", ret);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_rsa_keygen_int", ret);
 
     return ret;
 }
@@ -861,18 +871,18 @@ static int we_rsa_keygen(RSA *osslKey, int bits, BIGNUM *eBn, BN_GENCB *cb)
 
     (void)cb; /* Callback not supported, yet. */
 
-    WOLFENGINE_ENTER("we_rsa_keygen");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_rsa_keygen");
 
     engineRsa = (we_Rsa *)RSA_get_app_data(osslKey);
     if (engineRsa == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("RSA_get_app_data", engineRsa);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "RSA_get_app_data", engineRsa);
         ret = 0;
     }
 
     if (ret == 1) {
         e = (long)BN_get_word(eBn);
         if (e == -1) {
-            WOLFENGINE_ERROR_FUNC("BN_get_word", (int)e);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "BN_get_word", (int)e);
             ret = 0;
         }
     }
@@ -880,12 +890,12 @@ static int we_rsa_keygen(RSA *osslKey, int bits, BIGNUM *eBn, BN_GENCB *cb)
     if (ret == 1) {
         rc = we_rsa_keygen_int(&engineRsa->key, &osslKey, bits, e);
         if (rc != 1) {
-            WOLFENGINE_ERROR_FUNC("we_rsa_keygen_int", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "we_rsa_keygen_int", rc);
             ret = 0;
         }
     }
 
-    WOLFENGINE_LEAVE("we_rsa_keygen", ret);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_rsa_keygen", ret);
 
     return ret;
 }
@@ -899,11 +909,11 @@ int we_init_rsa_meth(void)
 {
     int ret = 1;
 
-    WOLFENGINE_ENTER("we_init_rsa_meth");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_init_rsa_meth");
 
     we_rsa_method = RSA_meth_new("wolfengine_rsa", 0);
     if (we_rsa_method == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("RSA_meth_new", we_rsa_method);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "RSA_meth_new", we_rsa_method);
         ret = 0;
     }
 
@@ -922,7 +932,7 @@ int we_init_rsa_meth(void)
         we_rsa_method = NULL;
     }
 
-    WOLFENGINE_LEAVE("we_init_rsa_meth", ret);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_init_rsa_meth", ret);
 
     return ret;
 }
@@ -944,18 +954,18 @@ static int we_rsa_pkey_init(EVP_PKEY_CTX *ctx)
     int rc = 0;
     we_Rsa *rsa;
 
-    WOLFENGINE_ENTER("we_rsa_pkey_init");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_rsa_pkey_init");
 
     rsa = (we_Rsa *)OPENSSL_zalloc(sizeof(we_Rsa));
     if (rsa == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("OPENSSL_zalloc", rsa);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "OPENSSL_zalloc", rsa);
         ret = 0;
     }
 
     if (ret == 1) {
         rc = wc_InitRsaKey(&rsa->key, NULL);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_InitRsaKey", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_InitRsaKey", rc);
             ret = 0;
         }
     }
@@ -971,7 +981,7 @@ static int we_rsa_pkey_init(EVP_PKEY_CTX *ctx)
         OPENSSL_free(rsa);
     }
 
-    WOLFENGINE_LEAVE("we_rsa_pkey_init", ret);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_rsa_pkey_init", ret);
 
     return ret;
 }
@@ -985,7 +995,7 @@ static void we_rsa_pkey_cleanup(EVP_PKEY_CTX *ctx)
 {
     we_Rsa *rsa = (we_Rsa *)EVP_PKEY_CTX_get_data(ctx);
 
-    WOLFENGINE_ENTER("we_rsa_pkey_cleanup");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_rsa_pkey_cleanup");
 
     if (rsa != NULL) {
         wc_FreeRsaKey(&rsa->key);
@@ -1012,8 +1022,8 @@ static int we_rsa_pkey_copy(EVP_PKEY_CTX *dst, EVP_PKEY_CTX *src)
     (void)dst;
     (void)src;
  
-    WOLFENGINE_ENTER("we_rsa_pkey_copy");
-    WOLFENGINE_LEAVE("we_rsa_pkey_copy", ret);
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_rsa_pkey_copy");
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_rsa_pkey_copy", ret);
 
     return ret;
 }
@@ -1032,11 +1042,12 @@ static int we_rsa_pkey_keygen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
     we_Rsa *engineRsa = NULL;
     RSA *rsa = NULL;
 
-    WOLFENGINE_ENTER("we_rsa_pkey_keygen");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_rsa_pkey_keygen");
 
     engineRsa = (we_Rsa *)EVP_PKEY_CTX_get_data(ctx);
     if (engineRsa == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("EVP_PKEY_CTX_get_data", engineRsa);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "EVP_PKEY_CTX_get_data",
+                                   engineRsa);
         ret = 0;
     }
 
@@ -1044,7 +1055,7 @@ static int we_rsa_pkey_keygen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
         rc = we_rsa_keygen_int(&engineRsa->key, &rsa, engineRsa->bits,
                                engineRsa->pubExp);
         if (rc == 0) {
-            WOLFENGINE_ERROR_FUNC("we_rsa_keygen_int", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "we_rsa_keygen_int", rc);
             ret = 0;
         }
     }
@@ -1052,11 +1063,11 @@ static int we_rsa_pkey_keygen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
     if (ret == 1) {
         ret = EVP_PKEY_assign_RSA(pkey, rsa);
         if (ret == 0) {
-            WOLFENGINE_ERROR_FUNC("EVP_PKEY_assign_RSA", ret);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "EVP_PKEY_assign_RSA", ret);
         }
     }
 
-    WOLFENGINE_LEAVE("we_rsa_pkey_keygen", ret);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_rsa_pkey_keygen", ret);
 
     return ret;
 }
@@ -1085,11 +1096,11 @@ static int we_rsa_pkey_ctrl(EVP_PKEY_CTX *ctx, int type, int num, void *ptr)
     long e;
     char errBuff[WOLFENGINE_MAX_ERROR_SZ];
 
-    WOLFENGINE_ENTER("we_rsa_pkey_ctrl");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_rsa_pkey_ctrl");
 
     rsa = (we_Rsa *)EVP_PKEY_CTX_get_data(ctx);
     if (rsa == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("EVP_PKEY_CTX_get_data", rsa);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "EVP_PKEY_CTX_get_data", rsa);
         ret = 0;
     }
 
@@ -1101,7 +1112,8 @@ static int we_rsa_pkey_ctrl(EVP_PKEY_CTX *ctx, int type, int num, void *ptr)
                     num != RSA_PKCS1_OAEP_PADDING &&
                     num != RSA_NO_PADDING)
                 {
-                    WOLFENGINE_ERROR_MSG("Unsupported RSA padding mode.");
+                    WOLFENGINE_ERROR_MSG(WE_LOG_PK,
+                                         "Unsupported RSA padding mode.");
                     ret = 0;
                 }
                 else {
@@ -1122,14 +1134,16 @@ static int we_rsa_pkey_ctrl(EVP_PKEY_CTX *ctx, int type, int num, void *ptr)
 #if OPENSSL_VERSION_NUMBER >= 0x1010100fL
             case EVP_PKEY_CTRL_RSA_KEYGEN_PRIMES:
                 /* wolfCrypt can only do key generation with 2 primes. */
-                WOLFENGINE_ERROR_MSG("wolfCrypt does not support multi-prime"
+                WOLFENGINE_ERROR_MSG(WE_LOG_PK,
+                                     "wolfCrypt does not support multi-prime"
                                      "RSA.");
                 ret = 0;
                 break;
 #endif
             case EVP_PKEY_CTRL_RSA_KEYGEN_BITS:
                 if (num < RSA_MIN_SIZE || num > RSA_MAX_SIZE) {
-                    WOLFENGINE_ERROR_MSG("RSA key size not in range.");
+                    WOLFENGINE_ERROR_MSG(WE_LOG_PK,
+                                         "RSA key size not in range.");
                     ret = 0;
                 }
                 else {
@@ -1141,11 +1155,13 @@ static int we_rsa_pkey_ctrl(EVP_PKEY_CTX *ctx, int type, int num, void *ptr)
                 bn = (BIGNUM*)ptr;
                 e = (long)BN_get_word(bn);
                 if (e == -1) {
-                    WOLFENGINE_ERROR_MSG("RSA public exponent too large.");
+                    WOLFENGINE_ERROR_MSG(WE_LOG_PK,
+                                         "RSA public exponent too large.");
                     ret = 0;
                 }
                 if (ret == 1 && e == 0) {
-                    WOLFENGINE_ERROR_MSG("RSA public exponent is 0.");
+                    WOLFENGINE_ERROR_MSG(WE_LOG_PK,
+                                         "RSA public exponent is 0.");
                     ret = 0;
                 }
                 if (ret == 1) {
@@ -1171,13 +1187,13 @@ static int we_rsa_pkey_ctrl(EVP_PKEY_CTX *ctx, int type, int num, void *ptr)
             default:
                 XSNPRINTF(errBuff, sizeof(errBuff), "Unsupported ctrl type %d",
                           type);
-                WOLFENGINE_ERROR_MSG(errBuff);
+                WOLFENGINE_ERROR_MSG(WE_LOG_PK, errBuff);
                 ret = 0;
                 break;
         }
     }
     
-    WOLFENGINE_LEAVE("we_rsa_pkey_ctrl", ret);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_rsa_pkey_ctrl", ret);
 
     return ret;
 }
@@ -1202,11 +1218,11 @@ static int we_rsa_pkey_ctrl_str(EVP_PKEY_CTX *ctx, const char *type,
     int ret = 1;
     we_Rsa *rsa = NULL;
 
-    WOLFENGINE_ENTER("we_rsa_pkey_ctrl_str");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_rsa_pkey_ctrl_str");
 
     rsa = (we_Rsa *)EVP_PKEY_CTX_get_data(ctx);
     if (rsa == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("EVP_PKEY_CTX_get_data", rsa);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "EVP_PKEY_CTX_get_data", rsa);
         ret = 0;
     }
 
@@ -1282,12 +1298,13 @@ static int we_der_encode_digest(const EVP_MD *md, const unsigned char *digest,
     int ret = 1;
     int hashOID = 0;
 
-    WOLFENGINE_ENTER("we_der_encode_digest");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_der_encode_digest");
 
     if (*encodedDigest == NULL) {
         *encodedDigest = (unsigned char *)OPENSSL_malloc(MAX_DER_DIGEST_SZ);
         if (*encodedDigest == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("OPENSSL_malloc", *encodedDigest);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "OPENSSL_malloc",
+                                       *encodedDigest);
             ret = 0;
         }
     }
@@ -1295,7 +1312,7 @@ static int we_der_encode_digest(const EVP_MD *md, const unsigned char *digest,
     if (ret == 1) {
         hashOID = we_nid_to_wc_hash_oid(EVP_MD_type(md));
         if (hashOID <= 0) {
-            WOLFENGINE_ERROR_FUNC("we_nid_to_wc_hash_oid", hashOID);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "we_nid_to_wc_hash_oid", hashOID);
             ret = 0;
         }
     }
@@ -1304,11 +1321,11 @@ static int we_der_encode_digest(const EVP_MD *md, const unsigned char *digest,
         ret = wc_EncodeSignature(*encodedDigest, digest, (word32)digestLen,
                                  hashOID);
         if (ret == 0) {
-            WOLFENGINE_ERROR_FUNC("wc_EncodeSignature", ret);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_EncodeSignature", ret);
         }
     }
 
-    WOLFENGINE_LEAVE("we_der_encode_digest", ret);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_der_encode_digest", ret);
 
     return ret;
 }
@@ -1337,11 +1354,11 @@ static int we_rsa_pkey_sign(EVP_PKEY_CTX *ctx, unsigned char *sig,
     int len;
     int actualSigLen = 0;
 
-    WOLFENGINE_ENTER("we_rsa_pkey_sign");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_rsa_pkey_sign");
 
     rsa = (we_Rsa *)EVP_PKEY_CTX_get_data(ctx);
     if (rsa == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("EVP_PKEY_CTX_get_data", rsa);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "EVP_PKEY_CTX_get_data", rsa);
         ret = 0;
     }
 
@@ -1349,20 +1366,22 @@ static int we_rsa_pkey_sign(EVP_PKEY_CTX *ctx, unsigned char *sig,
     if (ret == 1 && !rsa->privKeySet) {
         pkey = EVP_PKEY_CTX_get0_pkey(ctx);
         if (pkey == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("EVP_PKEY_CTX_get0_pkey", pkey);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "EVP_PKEY_CTX_get0_pkey",
+                                       pkey);
             ret = 0;
         }
         if (ret == 1) {
             rsaKey = (RSA*)EVP_PKEY_get0_RSA(pkey);
             if (rsaKey == NULL) {
-                WOLFENGINE_ERROR_FUNC_NULL("EVP_PKEY_get0_RSA", rsaKey);
+                WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "EVP_PKEY_get0_RSA",
+                                           rsaKey);
                 ret = 0;
             }
         }
         if (ret == 1) {
             ret = we_set_private_key(rsaKey, rsa);
             if (ret == 0) {
-                WOLFENGINE_ERROR_FUNC("we_set_private_key", ret);
+                WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "we_set_private_key", ret);
             }
         }
     }
@@ -1371,7 +1390,7 @@ static int we_rsa_pkey_sign(EVP_PKEY_CTX *ctx, unsigned char *sig,
         len = wc_SignatureGetSize(WC_SIGNATURE_TYPE_RSA, &rsa->key,
                                   sizeof(rsa->key));
         if (len <= 0) {
-            WOLFENGINE_ERROR_FUNC("wc_SignatureGetSize", (int)len);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_SignatureGetSize", (int)len);
             ret = 0;
         }
         else {
@@ -1387,7 +1406,7 @@ static int we_rsa_pkey_sign(EVP_PKEY_CTX *ctx, unsigned char *sig,
             encodedDigestLen = we_der_encode_digest(rsa->md, tbs, tbsLen,
                                                     &encodedDigest);
             if (encodedDigestLen == 0) {
-                WOLFENGINE_ERROR_FUNC("we_der_encode_digest",
+                WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "we_der_encode_digest",
                                       encodedDigestLen);
                 ret = 0;
             }
@@ -1399,7 +1418,8 @@ static int we_rsa_pkey_sign(EVP_PKEY_CTX *ctx, unsigned char *sig,
         if (ret == 1) {
             actualSigLen = we_rsa_priv_enc_int(tbsLen, tbs, *sigLen, sig, rsa);
             if (actualSigLen == -1) {
-                WOLFENGINE_ERROR_FUNC("we_rsa_priv_enc_int", actualSigLen);
+                WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "we_rsa_priv_enc_int",
+                                      actualSigLen);
                 ret = 0;
             }
             else {
@@ -1412,7 +1432,7 @@ static int we_rsa_pkey_sign(EVP_PKEY_CTX *ctx, unsigned char *sig,
         OPENSSL_free(encodedDigest);
     }
 
-    WOLFENGINE_LEAVE("we_rsa_pkey_sign", ret);
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_rsa_pkey_sign", ret);
 
     return ret;
 }
@@ -1440,11 +1460,11 @@ static int we_rsa_pkey_verify(EVP_PKEY_CTX *ctx, const unsigned char *sig,
     unsigned char *encodedDigest = NULL;
     int encodedDigestLen = 0;
 
-    WOLFENGINE_ENTER("we_rsa_pkey_verify");
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_rsa_pkey_verify");
 
     rsa = (we_Rsa *)EVP_PKEY_CTX_get_data(ctx);
     if (rsa == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("EVP_PKEY_CTX_get_data", rsa);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "EVP_PKEY_CTX_get_data", rsa);
         ret = 0;
     }
 
@@ -1452,20 +1472,22 @@ static int we_rsa_pkey_verify(EVP_PKEY_CTX *ctx, const unsigned char *sig,
     if (ret == 1 && !rsa->pubKeySet) {
         pkey = EVP_PKEY_CTX_get0_pkey(ctx);
         if (pkey == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("EVP_PKEY_CTX_get0_pkey", pkey);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "EVP_PKEY_CTX_get0_pkey",
+                                       pkey);
             ret = 0;
         }
         if (ret == 1) {
             rsaKey = (RSA*)EVP_PKEY_get0_RSA(pkey);
             if (rsaKey == NULL) {
-                WOLFENGINE_ERROR_FUNC_NULL("EVP_PKEY_get0_RSA", rsaKey);
+                WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "EVP_PKEY_get0_RSA",
+                                           rsaKey);
                 ret = 0;
             }
         }
         if (ret == 1) {
             ret = we_set_public_key(rsaKey, rsa);
             if (ret == 0) {
-                WOLFENGINE_ERROR_FUNC("we_set_public_key", ret);
+                WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "we_set_public_key", ret);
             }
         }
     }
@@ -1473,7 +1495,8 @@ static int we_rsa_pkey_verify(EVP_PKEY_CTX *ctx, const unsigned char *sig,
     if (ret == 1) {
         decryptedSig = (unsigned char *)OPENSSL_malloc(sigLen);
         if (decryptedSig == NULL) {
-            WOLFENGINE_ERROR_FUNC_NULL("OPENSSL_malloc", decryptedSig);
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "OPENSSL_malloc",
+                                       decryptedSig);
             ret = 0;
         }
     }
@@ -1481,7 +1504,7 @@ static int we_rsa_pkey_verify(EVP_PKEY_CTX *ctx, const unsigned char *sig,
     if (ret == 1) {
         rc = we_rsa_pub_dec_int(sigLen, sig, sigLen, decryptedSig, rsa);
         if (rc == -1) {
-            WOLFENGINE_ERROR_FUNC("we_rsa_pub_dec_int", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "we_rsa_pub_dec_int", rc);
             ret = 0;
         }
     }
@@ -1492,7 +1515,7 @@ static int we_rsa_pkey_verify(EVP_PKEY_CTX *ctx, const unsigned char *sig,
         rc = wc_RsaPSS_CheckPadding_ex(tbs, tbsLen, decryptedSig, rc,
             we_nid_to_wc_hash_type(EVP_MD_type(rsa->md)), rsa->saltLen, 0);
         if (rc != 0) {
-            WOLFENGINE_ERROR_FUNC("wc_RsaPSS_CheckPadding_ex", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_RsaPSS_CheckPadding_ex", rc);
             ret = 0;
         }
     }
@@ -1504,7 +1527,8 @@ static int we_rsa_pkey_verify(EVP_PKEY_CTX *ctx, const unsigned char *sig,
             encodedDigestLen = we_der_encode_digest(rsa->md, tbs, tbsLen,
                                                     &encodedDigest);
             if (encodedDigestLen == 0) {
-                WOLFENGINE_ERROR_FUNC("we_der_encode_digest", encodedDigestLen);
+                WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "we_der_encode_digest",
+                                      encodedDigestLen);
                 ret = 0;
             }
             else {
@@ -1515,7 +1539,7 @@ static int we_rsa_pkey_verify(EVP_PKEY_CTX *ctx, const unsigned char *sig,
         if (ret == 1) {
             rc = XMEMCMP(tbs, decryptedSig, tbsLen);
             if (rc != 0) {
-                WOLFENGINE_ERROR_FUNC("XMEMCMP", rc);
+                WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "XMEMCMP", rc);
                 ret = 0;
             }
         }
@@ -1543,7 +1567,8 @@ int we_init_rsa_pkey_meth(void)
 
     we_rsa_pkey_method = EVP_PKEY_meth_new(EVP_PKEY_RSA, 0);
     if (we_rsa_pkey_method == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("EVP_PKEY_meth_new", we_rsa_pkey_method);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "EVP_PKEY_meth_new",
+                                   we_rsa_pkey_method);
         ret = 0;
     }
 

--- a/src/we_logging.c
+++ b/src/we_logging.c
@@ -36,6 +36,17 @@ static wolfEngine_Logging_cb log_function = NULL;
  * wolfEngine_Debugging_ON() and wolfEngine_Debugging_OFF() */
 static int loggingEnabled = 0;
 
+/* Logging level. Bitmask of logging levels in wolfEngine_LogType.
+ * Can be set by application through ENGINE_ctrl command. Default log
+ * level includes error, enter/leave, and info. Does not turn on verbose
+ * by default. */
+static int engineLogLevel = WE_LOG_LEVEL_DEFAULT;
+
+/* Components which will be logged when debug enabled. Bitmask of components
+ * in wolfEngine_LogComponents. Can be set by application through ENGINE_ctrl
+ * command. Default components include all. */
+static int engineLogComponents = WE_LOG_COMPONENTS_DEFAULT;
+
 #endif /* WOLFENGINE_DEBUG */
 
 
@@ -86,6 +97,44 @@ void wolfEngine_Debugging_OFF(void)
 #endif
 }
 
+/**
+ * Set wolfEngine logging level.
+ * Deafult logging level for wolfEngine is WE_LOG_LEVEL_DEFAULT.
+ *
+ * @param levelMask [IN] Bitmask of logging levels from wolfEngine_LogType
+ *                  in we_logging.h.
+ * @return 0 on success, NOT_COMPILED_IN if debugging has not been enabled.
+ */
+int wolfEngine_SetLogLevel(int levelMask)
+{
+#ifdef WOLFENGINE_DEBUG
+    engineLogLevel = levelMask;
+    return 0;
+#else
+    (void)levelMask;
+    return NOT_COMPILED_IN;
+#endif
+}
+
+/**
+ * Set which components to log in wolfEngine debug logs.
+ * Default component level for wolfEngine is WE_LOG_COMPONENT_DEFAULT.
+ *
+ * @param componentMask [IN] Bitmask of components from
+ *                      wolfEngine_LogComponents in we_logging.h.
+ * @return 0 on success, NOT_COMPILED_IN if debugging has not been enabled.
+ */
+int wolfEngine_SetLogComponents(int componentMask)
+{
+#ifdef WOLFENGINE_DEBUG
+    engineLogComponents = componentMask;
+    return 0;
+#else
+    (void)componentMask;
+    return NOT_COMPILED_IN;
+#endif
+}
+
 #ifdef WOLFENGINE_DEBUG
 
 /**
@@ -96,10 +145,19 @@ void wolfEngine_Debugging_OFF(void)
  * @param logLevel   [IN] Log level.
  * @param logMessage [IN] Log message.
  */
-static void wolfengine_log(const int logLevel, const char *const logMessage)
+static void wolfengine_log(const int logLevel, const int component,
+                           const char *const logMessage)
 {
+    /* Don't log messages that do not match our current logging level */
+    if ((engineLogLevel & logLevel) != logLevel)
+        return;
+
+    /* Don't log messages from components that do not match enabled list */
+    if ((engineLogComponents & component) != component)
+        return;
+
     if (log_function) {
-        log_function(logLevel, logMessage);
+        log_function(logLevel, component, logMessage);
     } else {
 #if defined(WOLFENGINE_USER_LOG)
         WOLFENGINE_USER_LOG(logMessage);
@@ -114,77 +172,83 @@ static void wolfengine_log(const int logLevel, const char *const logMessage)
 /**
  * Log function for general messages.
  *
+ * @param component [IN] Component type, from wolfEngine_LogComponents enum.
  * @param msg  [IN] Log message.
  */
-void WOLFENGINE_MSG(const char* msg)
+void WOLFENGINE_MSG(int component, const char* msg)
 {
     if (loggingEnabled) {
-        wolfengine_log(WE_LOG_INFO, msg);
+        wolfengine_log(WE_LOG_INFO, component, msg);
     }
 }
 
 /**
  * Log function used to record function entry.
  *
+ * @param component [IN] Component type, from wolfEngine_LogComponents enum.
  * @param msg  [IN] Log message.
  */
-void WOLFENGINE_ENTER(const char* msg)
+void WOLFENGINE_ENTER(int component, const char* msg)
 {
     if (loggingEnabled) {
         char buffer[WOLFENGINE_MAX_ERROR_SZ];
         XSNPRINTF(buffer, sizeof(buffer), "wolfEngine Entering %s", msg);
-        wolfengine_log(WE_LOG_ENTER, buffer);
+        wolfengine_log(WE_LOG_ENTER, component, buffer);
     }
 }
 
 /**
  * Log function used to record function exit.
  *
+ * @param component [IN] Component type, from wolfEngine_LogComponents enum.
  * @param msg  [IN] Log message.
  * @param ret  [IN] Value that function will be returning.
  */
-void WOLFENGINE_LEAVE(const char* msg, int ret)
+void WOLFENGINE_LEAVE(int component, const char* msg, int ret)
 {
     if (loggingEnabled) {
         char buffer[WOLFENGINE_MAX_ERROR_SZ];
         XSNPRINTF(buffer, sizeof(buffer), "wolfEngine Leaving %s, return %d",
                   msg, ret);
-        wolfengine_log(WE_LOG_LEAVE, buffer);
+        wolfengine_log(WE_LOG_LEAVE, component, buffer);
     }
 }
 
 /**
  * Log function for error code, general error message.
  *
+ * @param component [IN] Component type, from wolfEngine_LogComponents enum.
  * @param error  [IN] error code to be logged.
  * @param file   [IN] Source file where error is called. 
  * @param line   [IN] Line in source file where error is called. 
  */
-void WOLFENGINE_ERROR_LINE(int error, const char* file, int line)
+void WOLFENGINE_ERROR_LINE(int component, int error, const char* file, int line)
 {
     if (loggingEnabled) {
         char buffer[WOLFENGINE_MAX_ERROR_SZ];
         XSNPRINTF(buffer, sizeof(buffer),
                   "%s:%d - wolfEngine error occurred, error = %d", file, line,
                   error);
-        wolfengine_log(WE_LOG_ERROR, buffer);
+        wolfengine_log(WE_LOG_ERROR, component, buffer);
     }
 }
 
 /**
  * Log function for error message.
  *
+ * @param component [IN] Component type, from wolfEngine_LogComponents enum.
  * @param msg  [IN] Error message.
  * @param file [IN] Source file where error is called. 
  * @param line [IN] Line in source file where error is called. 
  */
-void WOLFENGINE_ERROR_MSG_LINE(const char* msg, const char* file, int line)
+void WOLFENGINE_ERROR_MSG_LINE(int component, const char* msg,
+                               const char* file, int line)
 {
     if (loggingEnabled) {
         char buffer[WOLFENGINE_MAX_ERROR_SZ];
         XSNPRINTF(buffer, sizeof(buffer), "%s:%d - wolfEngine Error %s",
                   file, line, msg);
-        wolfengine_log(WE_LOG_ERROR, buffer);
+        wolfengine_log(WE_LOG_ERROR, component, buffer);
     }
 }
 
@@ -192,20 +256,21 @@ void WOLFENGINE_ERROR_MSG_LINE(const char* msg, const char* file, int line)
  * Log function to convey function name and error for functions returning an
  * integer return code.
  *
+ * @param component [IN] Component type, from wolfEngine_LogComponents enum.
  * @param funcName  [IN] Name of function called.
  * @param ret       [IN] Return of function.
  * @param file      [IN] Source file where error is called. 
  * @param line      [IN] Line in source file where error is called. 
  */
-void WOLFENGINE_ERROR_FUNC_LINE(const char* funcName, int ret, const char* file,
-                                int line)
+void WOLFENGINE_ERROR_FUNC_LINE(int component, const char* funcName, int ret,
+                                const char* file, int line)
 {
     if (loggingEnabled) {
         char buffer[WOLFENGINE_MAX_ERROR_SZ];
         XSNPRINTF(buffer, sizeof(buffer),
                   "%s:%d - Error calling %s: ret = %d", file, line, funcName,
                   ret);
-        wolfengine_log(WE_LOG_ERROR, buffer);
+        wolfengine_log(WE_LOG_ERROR, component, buffer);
     }
 }
 
@@ -213,20 +278,21 @@ void WOLFENGINE_ERROR_FUNC_LINE(const char* funcName, int ret, const char* file,
  * Log function to convey function name and error for functions returning a
  * pointer.
  *
+ * @param component [IN] Component type, from wolfEngine_LogComponents enum.
  * @param funcName  [IN] Name of function called.
  * @param ret       [IN] Return of function.
  * @param file      [IN] Source file where error is called. 
  * @param line      [IN] Line in source file where error is called. 
  */
-void WOLFENGINE_ERROR_FUNC_NULL_LINE(const char* funcName, void *ret,
-                                     const char* file, int line)
+void WOLFENGINE_ERROR_FUNC_NULL_LINE(int component, const char* funcName,
+                                     void *ret, const char* file, int line)
 {
     if (loggingEnabled) {
         char buffer[WOLFENGINE_MAX_ERROR_SZ];
         XSNPRINTF(buffer, sizeof(buffer),
                   "%s:%d - Error calling %s: ret = %p", file, line, funcName,
                   ret);
-        wolfengine_log(WE_LOG_ERROR, buffer);
+        wolfengine_log(WE_LOG_ERROR, component, buffer);
     }
 }
 
@@ -239,10 +305,12 @@ void WOLFENGINE_ERROR_FUNC_NULL_LINE(const char* funcName, void *ret,
 /**
  * Log function to print buffer.
  *
+ * @param component [IN] Component type, from wolfEngine_LogComponents enum.
  * @param buffer  [IN] Buffer to print.
  * @param length  [IN] Length of buffer, octets.
  */
-void WOLFENGINE_BUFFER(const unsigned char* buffer, unsigned int length)
+void WOLFENGINE_BUFFER(int component, const unsigned char* buffer,
+                       unsigned int length)
 {
     int i, buflen = (int)length, bufidx;
     char line[(WOLFENGINE_LINE_LEN * 4) + 3]; /* \t00..0F | chars...chars\0 */
@@ -252,7 +320,7 @@ void WOLFENGINE_BUFFER(const unsigned char* buffer, unsigned int length)
     }
 
     if (!buffer) {
-        wolfengine_log(WE_LOG_VERBOSE, "\tNULL");
+        wolfengine_log(WE_LOG_VERBOSE, component, "\tNULL");
         return;
     }
 
@@ -283,7 +351,7 @@ void WOLFENGINE_BUFFER(const unsigned char* buffer, unsigned int length)
             }
         }
 
-        wolfengine_log(WE_LOG_VERBOSE, line);
+        wolfengine_log(WE_LOG_VERBOSE, component, line);
         buffer += WOLFENGINE_LINE_LEN;
         buflen -= WOLFENGINE_LINE_LEN;
     }

--- a/src/wolfengine.c
+++ b/src/wolfengine.c
@@ -43,21 +43,21 @@ static ENGINE *engine_wolfengine(void)
     int rc;
     ENGINE *ret;
 
-    WOLFENGINE_ENTER("engine_wolfengine");
+    WOLFENGINE_ENTER(WE_LOG_ENGINE, "engine_wolfengine");
 
     ret = ENGINE_new();
     if (ret == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL("ENGINE_new", ret);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_ENGINE, "ENGINE_new", ret);
         return NULL;
     }
     rc = wolfengine_bind(ret, wolfengine_lib);
     if (rc == 0) {
-        WOLFENGINE_ERROR_FUNC("wolfengine_bind", rc);
+        WOLFENGINE_ERROR_FUNC(WE_LOG_ENGINE, "wolfengine_bind", rc);
         ENGINE_free(ret);
         return NULL;
     }
 
-    WOLFENGINE_LEAVE("engine_wolfengine", 1);
+    WOLFENGINE_LEAVE(WE_LOG_ENGINE, "engine_wolfengine", 1);
 
     return ret;
 }
@@ -67,7 +67,7 @@ static ENGINE *engine_wolfengine(void)
  */
 void ENGINE_load_wolfengine(void)
 {
-    WOLFENGINE_ENTER("ENGINE_load_wolfengine");
+    WOLFENGINE_ENTER(WE_LOG_ENGINE, "ENGINE_load_wolfengine");
 
     ENGINE *toadd = engine_wolfengine();
     if (!toadd)
@@ -76,7 +76,7 @@ void ENGINE_load_wolfengine(void)
     ENGINE_free(toadd);
     ERR_clear_error();
 
-    WOLFENGINE_LEAVE("ENGINE_load_wolfengine", 1);
+    WOLFENGINE_LEAVE(WE_LOG_ENGINE, "ENGINE_load_wolfengine", 1);
 }
 
 #ifndef WE_NO_DYNAMIC_ENGINE

--- a/test/unit.h
+++ b/test/unit.h
@@ -34,6 +34,7 @@
 #include <openssl/aes.h>
 
 #include "openssl_bc.h"
+#include "we_logging.h"
 
 #define PRINT_MSG(str)         printf("MSG: %s\n", str)
 #define PRINT_ERR_MSG(str)     printf("ERR: %s\n", str)


### PR DESCRIPTION
This PR adds log levels and component-level logging.  Both can be controlled through ENGINE control commands with ENGINE_ctrl_cmd(), using the "log_level" and "log_components" commands.