### PR TITLE
Fix bug in we_rsa_priv_enc.

### DIFF
--- a/src/we_rsa.c
+++ b/src/we_rsa.c
@@ -532,10 +532,10 @@ static int we_rsa_priv_enc(int fromLen, const unsigned char *from,
         ret = -1;
     }
 
-    if (ret == 1 && !engineRsa->pubKeySet) {
-        rc = we_set_public_key(rsa, engineRsa);
+    if (ret == 1 && !engineRsa->privKeySet) {
+        rc = we_set_private_key(rsa, engineRsa);
         if (rc == 0) {
-            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "we_set_public_key", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "we_set_private_key", rc);
             ret = -1;
         }
     }

--- a/test/unit.c
+++ b/test/unit.c
@@ -125,7 +125,11 @@ TEST_CASE test_case[] = {
     TEST_DECL(test_random, NULL),
 #endif
 #ifdef WE_HAVE_RSA
-    TEST_DECL(test_rsa_direct, NULL),
+    TEST_DECL(test_rsa_direct_key_gen, NULL),
+    TEST_DECL(test_rsa_direct_priv_enc, NULL),
+    TEST_DECL(test_rsa_direct_priv_dec, NULL),
+    TEST_DECL(test_rsa_direct_pub_enc, NULL),
+    TEST_DECL(test_rsa_direct_pub_dec, NULL),
 #endif /* WE_HAVE_RSA */
 #ifdef WE_HAVE_DH
     TEST_DECL(test_dh, NULL),

--- a/test/unit.h
+++ b/test/unit.h
@@ -163,7 +163,11 @@ int test_pkey_verify(EVP_PKEY *pkey, ENGINE *e,
 #endif /* WE_HAVE_EVP_PKEY */
 
 #ifdef WE_HAVE_RSA
-int test_rsa_direct(ENGINE *e, void *data);
+int test_rsa_direct_key_gen(ENGINE *e, void *data);
+int test_rsa_direct_priv_enc(ENGINE *e, void *data);
+int test_rsa_direct_priv_dec(ENGINE *e, void *data);
+int test_rsa_direct_pub_enc(ENGINE *e, void *data);
+int test_rsa_direct_pub_dec(ENGINE *e, void *data);
 #ifdef WE_HAVE_EVP_PKEY
 int test_rsa_sign_verify_pkcs1(ENGINE *e, void *data);
 int test_rsa_sign_verify_no_pad(ENGINE *e, void *data);


### PR DESCRIPTION
We were setting the public key rather than the private key. I modified the RSA
direct unit tests so that this bug gets caught. Essentially, the changes make
it so no RSA direct test depends on the state of a prior RSA direct test.