### PR TITLE
Modify 3DES-CBC implementation to work with TLS 1.0/1.1 (e.g. DES-CBC3-SHA)

### DIFF
--- a/src/we_des3_cbc.c
+++ b/src/we_des3_cbc.c
@@ -35,10 +35,6 @@ typedef struct we_Des3Cbc
 {
     /** The wolfSSL DES3 data object. */
     Des3           des3;
-    /** Buffer for streaming. */
-    unsigned char  lastBlock[DES_BLOCK_SIZE];
-    /** Number of buffered bytes.  */
-    unsigned int   over;
     /** Flag to indicate whether wolfSSL DES3 object initialized. */
     unsigned int   init:1;
     /** Flag to indicate whether we are doing encrypt (1) or decrpyt (0). */
@@ -85,10 +81,7 @@ static int we_des3_cbc_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
     }
 
     if (ret == 1) {
-        /* Must have initialized wolfSSL DES3 object when here. */
         des3->init = 1;
-        des3->over = 0;
-        /* Store whether encrypting. */
         des3->enc = enc;
 
         if (key != NULL) {
@@ -121,104 +114,33 @@ static int we_des3_cbc_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
  * @param  ctx   [in/out]  EVP cipher context of operation.
  * @param  des3  [in]      Internal DES3-CBC object.
  * @param  out   [out]     Buffer to store enciphered result.
- * @param  in    [in]      Data to encrypt/decrypt.
- * @param  len   [in]      Length of data to encrypt/decrypt.
- * @return  -1 on failure.
- * @return  Number of bytes put in out on success.
+ * @param  in    [in]      Data to encrypt.
+ * @param  len   [in]      Length of data to encrypt.
+ * @return  0 on failure, 1 on success.
  */
 static int we_des3_cbc_encrypt(EVP_CIPHER_CTX *ctx, we_Des3Cbc* des3,
     unsigned char *out, const unsigned char *in, size_t len)
 {
     int ret = 1;
     int rc;
-    int outl = 0;
-    int noPad = EVP_CIPHER_CTX_test_flags(ctx, EVP_CIPH_NO_PADDING);
+
+    (void)ctx;
 
     WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_des3_cbc_encrypt");
 
-    /* Length of 0 means Final called. */
-    if (len == 0) {
-        if (noPad) {
-            if (des3->over != 0) {
-                WOLFENGINE_ERROR_MSG(WE_LOG_CIPHER,
-                                     "No Pad - last encrypt block not full");
-                ret = 0;
-            }
-        }
-        else {
-            byte pad = DES_BLOCK_SIZE - des3->over;
-
-            /* Padding - fill rest of block with number of padding blocks. */
-            XMEMSET(des3->lastBlock + des3->over, pad, pad);
-            des3->over = DES_BLOCK_SIZE;
-            /* Encrypt lastBlock and return in out. */
-        }
+    if (len % DES_BLOCK_SIZE) {
+        WOLFENGINE_ERROR_MSG(WE_LOG_CIPHER, "we_des3_cbc_encrypt: len must be "
+                                            "a multiple of DES_BLOCK_SIZE");
+        ret = 0;
     }
-    
+
     if (ret == 1) {
-        unsigned int l;
-
-        /* Check for cached data. */
-        if (des3->over > 0) {
-            /* Partial block not yet encrypted. */
-            l = DES_BLOCK_SIZE - des3->over;
-            if (l > len) {
-                l = (int)len;
-            }
-
-            /* Copy as much of input as possible to fill in block. */
-            if (l > 0) {
-                XMEMCPY(des3->lastBlock + des3->over, in, l);
-                des3->over += l;
-                in += l;
-                len -= l;
-            }
-            /* Check if we have a complete block to encrypt. */
-            if (des3->over == DES_BLOCK_SIZE) {
-                /* Encrypt and return block. */
-                rc = wc_Des3_CbcEncrypt(&des3->des3, out, des3->lastBlock,
-                                        DES_BLOCK_SIZE);
-                if (rc != 0) {
-                    WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER,
-                                          "wc_Des3_CbcEncrypt", rc);
-                    ret = 0;
-                }
-                /* Data put to output. */
-                out += DES_BLOCK_SIZE;
-                outl += DES_BLOCK_SIZE;
-                /* No more cached data. */
-                des3->over = 0;
-            }
+        rc = wc_Des3_CbcEncrypt(&des3->des3, out, in, (word32)len);
+        if (rc != 0) {
+            WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER,
+                                  "wc_Des3_CbcEncrypt", rc);
+            ret = 0;
         }
-        /* Encrypt full blocks from remaining input. */
-        if ((ret == 1) && (len >= DES_BLOCK_SIZE)) {
-            /* Calculate full blocks. */
-            l = (int)len & (~(DES_BLOCK_SIZE - 1));
-
-            rc = wc_Des3_CbcEncrypt(&des3->des3, out, in, l);
-            if (rc != 0) {
-                WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER,
-                                      "wc_Des3_CbcEncrypt", rc);
-                ret = 0;
-            }
-
-            outl += l;
-            in += l;
-            len -= l;
-        }
-        if ((ret == 1) && (len > 0)) {
-            /* Copy remaining input as incomplete block. */
-            XMEMCPY(des3->lastBlock, in, len);
-            des3->over = (int)len;
-        }
-    }
-    if (ret == 1) {
-        /* Return length of encrypted data. */
-        ret = outl;
-    }
-    else {
-        /* Return -ve for error. */
-        ret = -1;
     }
 
     WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_des3_cbc_encrypt", ret);
@@ -234,145 +156,33 @@ static int we_des3_cbc_encrypt(EVP_CIPHER_CTX *ctx, we_Des3Cbc* des3,
  * @param  ctx   [in/out]  EVP cipher context of operation.
  * @param  des3  [in]      Internal DES3-CBC object.
  * @param  out   [out]     Buffer to store enciphered result.
- * @param  in    [in]      Data to encrypt/decrypt.
- * @param  len   [in]      Length of data to encrypt/decrypt.
- * @return  -1 on failure.
- * @return  Number of bytes put in out on success.
+ * @param  in    [in]      Data to decrypt.
+ * @param  len   [in]      Length of data to decrypt.
+ * @return  0 on failure, 1 on success.
  */
 static int we_des3_cbc_decrypt(EVP_CIPHER_CTX *ctx, we_Des3Cbc* des3,
     unsigned char *out, const unsigned char *in, size_t len)
 {
     int ret = 1;
     int rc;
-    int outl = 0;
-    int noPad = EVP_CIPHER_CTX_test_flags(ctx, EVP_CIPH_NO_PADDING);
+
+    (void)ctx;
 
     WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_des3_cbc_decrypt");
 
-    /* Length of 0 means Final called. */
-    if (len == 0) {
-        if (noPad) {
-            if (des3->over != 0) {
-                WOLFENGINE_ERROR_MSG(WE_LOG_CIPHER,
-                                     "No Pad - last decrypt block not full");
-                ret = 0;
-            }
-        }
-        else {
-            byte pad;
-            int i;
-
-            /* Must have a full block over to decrypt. */
-            if (des3->over != DES_BLOCK_SIZE) {
-                WOLFENGINE_ERROR_MSG(WE_LOG_CIPHER,
-                                     "Padding - last cached decrypt block not "
-                                     "full");
-                ret = 0;
-            }
-            if (ret == 1) {
-                /* Decrypt last block - may be all padding. */
-                rc = wc_Des3_CbcDecrypt(&des3->des3, des3->lastBlock,
-                                        des3->lastBlock, DES_BLOCK_SIZE);
-                if (rc != 0) {
-                    WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER,
-                                          "wc_Des3_CbcDecrypt", rc);
-                    ret = 0;
-                }
-                des3->over = 0;
-            }
-            if (ret == 1) {
-                /* Last byte is length of padding. */
-                pad = des3->lastBlock[DES_BLOCK_SIZE - 1];
-                if ((pad == 0) || (pad > DES_BLOCK_SIZE)) {
-                    WOLFENGINE_ERROR_MSG(WE_LOG_CIPHER, "Padding byte invalid");
-                    ret = 0;
-                }
-            }
-            if (ret == 1) {
-                /* Copy out non-padding bytes. */
-                outl = DES_BLOCK_SIZE - pad;
-                XMEMCPY(out, des3->lastBlock, outl);
-                /* Check padding bytes are all the same. */
-                for (i = outl; (ret == 1) && (i < DES_BLOCK_SIZE - 1); i++) {
-                   if (des3->lastBlock[i] != pad) {
-                       WOLFENGINE_ERROR_MSG(WE_LOG_CIPHER,
-                                            "Padding byte doesn't different");
-                       ret = 0;
-                   }
-                }
-            }
-        }
+    if (len % DES_BLOCK_SIZE) {
+        WOLFENGINE_ERROR_MSG(WE_LOG_CIPHER, "we_des3_cbc_decrypt: len must be "
+                                            "a multiple of DES_BLOCK_SIZE");
+        ret = 0;
     }
+
     if (ret == 1) {
-        unsigned int l;
-
-        /* Check for cached data. */
-        if (des3->over > 0) {
-            /* Calculate amount of input that can be used. */
-            l = DES_BLOCK_SIZE - des3->over;
-            if (l > len) {
-                l = (int)len;
-            }
-
-            if (l > 0) {
-                /* Copy as much of input as possible to fill in block. */
-                XMEMCPY(des3->lastBlock + des3->over, in, l);
-                des3->over += l;
-                in += l;
-                len -= l;
-            }
-            /* Padding and not last full block or not padding and full block. */
-            if ((noPad && des3->over == DES_BLOCK_SIZE) || len > 0) {
-                /* Decrypt block cached block. */
-                rc = wc_Des3_CbcDecrypt(&des3->des3, out, des3->lastBlock,
-                                        DES_BLOCK_SIZE);
-                if (rc != 0) {
-                    WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER,
-                                          "wc_Des3_CbcDecrypt", rc);
-                    ret = 0;
-                }
-                /* Data put to output. */
-                out += DES_BLOCK_SIZE;
-                outl += DES_BLOCK_SIZE;
-                /* No more cached data. */
-                des3->over = 0;
-            }
+        rc = wc_Des3_CbcDecrypt(&des3->des3, out, in, (word32)len);
+        if (rc != 0) {
+            WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER,
+                                  "wc_Des3_CbcEncrypt 1", rc);
+            ret = 0;
         }
-        /* Decrypt full blocks from remaining input. */
-        if ((ret == 1) && (len >= DES_BLOCK_SIZE)) {
-            /* Calculate full blocks. */
-            l = (int)len & (~(DES_BLOCK_SIZE - 1));
-
-            /* Not last full block when padding. */
-            if ((!noPad) && (len - l == 0)) {
-                l -= DES_BLOCK_SIZE;
-            }
-            if (l > 0) {
-                rc = wc_Des3_CbcDecrypt(&des3->des3, out, in, l);
-                if (rc != 0) {
-                    WOLFENGINE_ERROR_FUNC(WE_LOG_CIPHER,
-                                          "wc_Des3_CbcDecrypt", rc);
-                    ret = 0;
-                }
-            }
-
-            outl += l;
-            in += l;
-            len -= l;
-        }
-        if ((ret == 1) && (len > 0)) {
-            /* Copy remaining input as incomplete block. */
-            XMEMCPY(des3->lastBlock, in, len);
-            des3->over = (int)len;
-        }
-    }
-    if (ret == 1) {
-        /* Return length of encrypted data. */
-        ret = outl;
-    }
-    else {
-        /* Return -ve for error. */
-        ret = -1;
     }
 
     WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_des3_cbc_decrypt", ret);
@@ -389,13 +199,12 @@ static int we_des3_cbc_decrypt(EVP_CIPHER_CTX *ctx, we_Des3Cbc* des3,
  * @param  out  [out]     Buffer to store enciphered result.
  * @param  in   [in]      Data to encrypt/decrypt.
  * @param  len  [in]      Length of data to encrypt/decrypt.
- * @return  -1 on failure.
- * @return  Number of bytes put in out on success.
+ * @return  0 on failure, 1 on success.
  */
 static int we_des3_cbc_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
                              const unsigned char *in, size_t len)
 {
-    int ret;
+    int ret = 1;
     we_Des3Cbc* des3;
 
     WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_des3_cbc_cipher");
@@ -405,13 +214,15 @@ static int we_des3_cbc_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
     if (des3 == NULL) {
         WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_CIPHER,
                                    "EVP_CIPHER_CTX_get_cipher_data", des3);
-        ret = -1;
+        ret = 0;
     }
-    else if (des3->enc) {
-        ret = we_des3_cbc_encrypt(ctx, des3, out, in, len);
-    }
-    else {
-        ret = we_des3_cbc_decrypt(ctx, des3, out, in, len);
+    if (ret == 1) {
+        if (des3->enc) {
+            ret = we_des3_cbc_encrypt(ctx, des3, out, in, len);
+        }
+        else {
+            ret = we_des3_cbc_decrypt(ctx, des3, out, in, len);
+        }
     }
 
     WOLFENGINE_LEAVE(WE_LOG_CIPHER, "we_des3_cbc_cipher", ret);
@@ -464,10 +275,15 @@ static int we_des3_cbc_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
     return ret;
 }
 
-/** Flags for DES3-CBC method. */
+/* Flags for DES3-CBC method.
+ *
+ * NOTE: EVP_CIPH_FLAG_CUSTOM_CIPHER is deliberately not added so that OpenSSL
+ *       handles the last block of encryption/decryption and padding itself.
+ *       Further, adding the flag will break wolfEngine compatibility with
+ *       certain TLS 1.0/1.1 ciphers.
+ */
 #define DES3_CBC_FLAGS             \
-    (EVP_CIPH_FLAG_CUSTOM_CIPHER | \
-     EVP_CIPH_ALWAYS_CALL_INIT   | \
+     (EVP_CIPH_ALWAYS_CALL_INIT  | \
      EVP_CIPH_FLAG_DEFAULT_ASN1  | \
      EVP_CIPH_CBC_MODE)
 
@@ -520,7 +336,8 @@ int we_init_des3cbc_meths()
     WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_init_des3cbc_meths");
 
     /* DES3-CBC */
-    we_des3_cbc_ciph = EVP_CIPHER_meth_new(NID_des_ede3_cbc, 1, DES3_KEY_SIZE);
+    we_des3_cbc_ciph = EVP_CIPHER_meth_new(NID_des_ede3_cbc, DES_BLOCK_SIZE,
+                                           DES3_KEY_SIZE);
     if (we_des3_cbc_ciph == NULL) {
         WOLFENGINE_ERROR_MSG(WE_LOG_CIPHER, "EVP_CIPHER_meth_new - DES3-CBC");
         ret = 0;

--- a/src/we_internal.c
+++ b/src/we_internal.c
@@ -876,13 +876,7 @@ static int wolfengine_destroy(ENGINE *e)
     EVP_MD_meth_free(we_sha3_512_md);
     we_sha3_512_md = NULL;
 #endif
-#ifdef WE_HAVE_HMAC
-    EVP_PKEY_meth_free(we_hmac_pkey_method);
-    we_hmac_pkey_method = NULL;
-#endif
 #ifdef WE_HAVE_CMAC
-    EVP_PKEY_meth_free(we_cmac_pkey_method);
-    we_cmac_pkey_method = NULL;
     EVP_PKEY_asn1_free(we_cmac_pkey_asn1_method);
     we_cmac_pkey_asn1_method = NULL;
 #endif


### PR DESCRIPTION
The design of our 3DES-CBC implementation up to this point is tied to the notion
of "update/final." That is, it expects that N bytes of data will be fed to it to
encrypt/decrypt via 1 or more calls to update (e.g. EVP_EncryptUpdate /
EVP_DecryptUpdate) followed by a call to final (e.g.
EVP_EncryptFinal_ex), which encrypts/decrypts any remaining data in the last
block and adds padding. This appears to be a fine design choice until we come to
a TLS 1.0 function in OpenSSL, tls1_enc. This function calls the deprecated
function EVP_Cipher (documentation instructs users to use EVP_CipherUpdate and
EVP_CipherFinal_ex instead) and adds the padding itself. This doesn't work with
our design because we'll be forever waiting for a call to final to finish the
last block of data and add padding. As far as I could tell while debugging the
code, there's no way for our current implementation to detect this scenario and
encrypt/decrypt the whole payload in one shot, without adding padding. So, our
options are then 1) Modify OpenSSL to work with the existing design
(not preferable) and 2) remove the EVP_CIPH_FLAG_CUSTOM_CIPHER flag and let
OpenSSL handle padding and the last bit of data for us. 2) also requires that we
simplify the encrypt/decrypt functions to just encrypt/decrypt the buffer
they're given and not have any notion of update/final.

This solves ZD 12021.