### PR TITLE
Make wolfEngine's RSA external data index configurable.

### DIFF
--- a/include/wolfengine/we_internal.h
+++ b/include/wolfengine/we_internal.h
@@ -29,6 +29,17 @@
     #include "user_settings.h"
 #endif
 
+/* This define controls the index used for the wolfEngine RSA external data
+ * in wolfEngine's RSA_METHOD implementation. This allows the user to put the
+ * wolfEngine external data at a specific index at compile time to avoid
+ * collisions with other, non-wolfEngine external data. For instance, you may
+ * have an application that is already using indexes 0 and 1, so you would
+ * define WE_RSA_EX_DATA_IDX to 2 to avoid colliding with the data at index 0
+ * (the default index). */
+#ifndef WE_RSA_EX_DATA_IDX
+#define WE_RSA_EX_DATA_IDX 0
+#endif
+
 #include <openssl/engine.h>
 #include <openssl/evp.h>
 #include <openssl/ec.h>

--- a/src/we_rsa.c
+++ b/src/we_rsa.c
@@ -188,9 +188,9 @@ static int we_rsa_init(RSA *rsa)
 #endif /* WC_RSA_BLINDING */
 
     if (ret == 1) {
-        rc = RSA_set_app_data(rsa, engineRsa);
+        rc = RSA_set_ex_data(rsa, WE_RSA_EX_DATA_IDX, engineRsa);
         if (rc != 1) {
-            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "RSA_set_app_data", rc);
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "RSA_set_ex_data", rc);
             ret = 0;
         }
     }
@@ -215,11 +215,11 @@ static int we_rsa_finish(RSA *rsa)
 
     WOLFENGINE_ENTER(WE_LOG_PK, "we_rsa_finish");
 
-    engineRsa = RSA_get_app_data(rsa);
+    engineRsa = (we_Rsa *)RSA_get_ex_data(rsa, WE_RSA_EX_DATA_IDX);
     if (engineRsa != NULL) {
         wc_FreeRsaKey(&engineRsa->key);
         OPENSSL_free(engineRsa);
-        RSA_set_app_data(rsa, NULL);
+        RSA_set_ex_data(rsa, WE_RSA_EX_DATA_IDX, NULL);
     }
 
     WOLFENGINE_LEAVE(WE_LOG_PK, "we_rsa_finish", 1);
@@ -246,9 +246,9 @@ static int we_rsa_pub_enc(int fromLen, const unsigned char *from,
 
     WOLFENGINE_ENTER(WE_LOG_PK, "we_rsa_pub_enc");
 
-    engineRsa = (we_Rsa *)RSA_get_app_data(rsa);
+    engineRsa = (we_Rsa *)RSA_get_ex_data(rsa, WE_RSA_EX_DATA_IDX);
     if (engineRsa == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "RSA_get_app_data", engineRsa);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "RSA_get_ex_data", engineRsa);
         ret = -1;
     }
 
@@ -334,9 +334,9 @@ static int we_rsa_priv_dec(int fromLen, const unsigned char *from,
 
     WOLFENGINE_ENTER(WE_LOG_PK, "we_rsa_priv_dec");
 
-    engineRsa = (we_Rsa *)RSA_get_app_data(rsa);
+    engineRsa = (we_Rsa *)RSA_get_ex_data(rsa, WE_RSA_EX_DATA_IDX);
     if (engineRsa == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "RSA_get_app_data", engineRsa);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "RSA_get_ex_data", engineRsa);
         ret = -1;
     }
 
@@ -527,9 +527,9 @@ static int we_rsa_priv_enc(int fromLen, const unsigned char *from,
 
     WOLFENGINE_ENTER(WE_LOG_PK, "we_rsa_priv_enc");
 
-    engineRsa = (we_Rsa *)RSA_get_app_data(rsa);
+    engineRsa = (we_Rsa *)RSA_get_ex_data(rsa, WE_RSA_EX_DATA_IDX);
     if (engineRsa == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "RSA_get_app_data", engineRsa);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "RSA_get_ex_data", engineRsa);
         ret = -1;
     }
 
@@ -643,9 +643,9 @@ static int we_rsa_pub_dec(int fromLen, const unsigned char *from,
 
     WOLFENGINE_ENTER(WE_LOG_PK, "we_rsa_pub_dec");
 
-    engineRsa = (we_Rsa *)RSA_get_app_data(rsa);
+    engineRsa = (we_Rsa *)RSA_get_ex_data(rsa, WE_RSA_EX_DATA_IDX);
     if (engineRsa == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "RSA_get_app_data", engineRsa);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "RSA_get_ex_data", engineRsa);
         ret = -1;
     }
 
@@ -875,9 +875,9 @@ static int we_rsa_keygen(RSA *osslKey, int bits, BIGNUM *eBn, BN_GENCB *cb)
 
     WOLFENGINE_ENTER(WE_LOG_PK, "we_rsa_keygen");
 
-    engineRsa = (we_Rsa *)RSA_get_app_data(osslKey);
+    engineRsa = (we_Rsa *)RSA_get_ex_data(osslKey, WE_RSA_EX_DATA_IDX);
     if (engineRsa == NULL) {
-        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "RSA_get_app_data", engineRsa);
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "RSA_get_ex_data", engineRsa);
         ret = 0;
     }
 


### PR DESCRIPTION
We've been defaulting to index 0, but in some applications, this index may
already be taken. This introduces a define, WE_RSA_EX_DATA_IDX, so that the
index can be changed at compile time to avoid collisions.

See ZD 12056 for customer request.