### PR TITLE
Fix 3DES-CBC IV length.

### DIFF
--- a/src/we_des3_cbc.c
+++ b/src/we_des3_cbc.c
@@ -302,7 +302,10 @@ static int we_init_des3cbc_meth(EVP_CIPHER *cipher)
 
     WOLFENGINE_ENTER(WE_LOG_CIPHER, "we_init_des3cbc_meth");
 
-    ret = EVP_CIPHER_meth_set_iv_length(cipher, DES_IV_SIZE);
+    /* NOTE: We intentionally set the IV length to DES_BLOCK_SIZE (8) here
+     *       rather than use DES_IV_SIZE, which is 16 in some wolfCrypt
+     *       versions. 8 is the correct value. */
+    ret = EVP_CIPHER_meth_set_iv_length(cipher, DES_BLOCK_SIZE);
     if (ret == 1) {
         ret = EVP_CIPHER_meth_set_flags(cipher, DES3_CBC_FLAGS);
     }


### PR DESCRIPTION
The IV length was set to 16 instead of 8. This stems from the fact that some
wolfCrypt versions set DES_IV_SIZE to 16. This appears to have been fixed in
more recent wolfCrypt versions, but not the one the customer is using. The
solution is to use DES_BLOCK_SIZE instead. This fixes an issue where
DES-CBC3-SHA + TLS 1.1 wasn't working.