### PR TITLE
Check the peer's public key with wc_DhCheckPubKey_ex before calling wc_DhAgree in DH code.

### DIFF
--- a/include/wolfengine/we_openssl_bc.h
+++ b/include/wolfengine/we_openssl_bc.h
@@ -162,6 +162,7 @@ size_t EC_POINT_point2buf(const EC_GROUP *group, const EC_POINT *point,
 
 const BIGNUM *DH_get0_p(const DH *dh);
 const BIGNUM *DH_get0_g(const DH *dh);
+const BIGNUM *DH_get0_q(const DH *dh);
 const BIGNUM *DH_get0_priv_key(const DH *dh);
 const BIGNUM *DH_get0_pub_key(const DH *dh);
 

--- a/src/we_openssl_bc.c
+++ b/src/we_openssl_bc.c
@@ -622,6 +622,17 @@ const BIGNUM *DH_get0_g(const DH *dh)
 #endif
 }
 
+const BIGNUM *DH_get0_q(const DH *dh)
+{
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+    return dh->q;
+#else
+    const BIGNUM *q;
+    DH_get0_pqg(dh, NULL, &q, NULL);
+    return q;
+#endif
+}
+
 const BIGNUM *DH_get0_priv_key(const DH *dh)
 {
 #if OPENSSL_VERSION_NUMBER < 0x10100000L


### PR DESCRIPTION
I discovered this issue when running OpenSSL's dhtest.c with wolfEngine. While
a preprocessor define, WOLFSSL_VALIDATE_FFC_IMPORT, will cause wc_DhAgree to
call wc_DhCheckPubKey before proceeding to compute the shared secret, this
function doesn't perform checks using the large prime q. However,
wc_DhCheckPubKey_ex does, and dhtest.c expects that these checks are performed.