### PR TITLE
Expand RSA functionality.

### DIFF
--- a/test/test_ecc.c
+++ b/test/test_ecc.c
@@ -801,6 +801,24 @@ int test_ecdh_p521(ENGINE *e, void *data)
 
 #ifdef WE_HAVE_ECDSA
 
+/* Convenience function for calling test_pkey_sign without RSA-specific
+   parameters. */
+static int test_pkey_sign_ecc(EVP_PKEY *pkey, ENGINE *e, unsigned char *hash,
+                              size_t hashLen, unsigned char *sig,
+                              size_t *sigLen)
+{
+    return test_pkey_sign(pkey, e, hash, hashLen, sig, sigLen, 0, NULL, NULL);
+}
+
+/* Convenience function for calling test_pkey_verify without RSA-specific
+   parameters. */
+static int test_pkey_verify_ecc(EVP_PKEY *pkey, ENGINE *e, unsigned char *hash,
+                                size_t hashLen, unsigned char *sig,
+                                size_t sigLen)
+{
+    return test_pkey_verify(pkey, e, hash, hashLen, sig, sigLen, 0, NULL, NULL);
+}
+
 #ifdef WE_HAVE_EC_P192
 int test_ecdsa_p192_pkey(ENGINE *e, void *data)
 {
@@ -822,32 +840,32 @@ int test_ecdsa_p192_pkey(ENGINE *e, void *data)
     if (err == 0) {
         PRINT_MSG("Sign with OpenSSL");
         ecdsaSigLen = sizeof(ecdsaSig);
-        err = test_pkey_sign(pkey, NULL, buf, sizeof(buf), ecdsaSig,
-                                   &ecdsaSigLen, 0);
+        err = test_pkey_sign_ecc(pkey, NULL, buf, sizeof(buf), ecdsaSig,
+                                 &ecdsaSigLen);
     }
     if (err == 0) {
         PRINT_MSG("Verify with wolfengine");
-        err = test_pkey_verify(pkey, e, buf, sizeof(buf), ecdsaSig,
-                                     ecdsaSigLen, 0);
+        err = test_pkey_verify_ecc(pkey, e, buf, sizeof(buf), ecdsaSig,
+                                   ecdsaSigLen);
     }
     if (err == 0) {
         PRINT_MSG("Verify bad signature with wolfengine");
         ecdsaSig[1] ^= 0x80;
-        res = test_pkey_verify(pkey, e, buf, sizeof(buf), ecdsaSig,
-                                     ecdsaSigLen, 0);
+        res = test_pkey_verify_ecc(pkey, e, buf, sizeof(buf), ecdsaSig,
+                                   ecdsaSigLen);
         if (res != 1)
             err = 1;
     }
     if (err == 0) {
         PRINT_MSG("Sign with wolfengine");
         ecdsaSigLen = sizeof(ecdsaSig);
-        err = test_pkey_sign(pkey, e, buf, sizeof(buf), ecdsaSig,
-                                   &ecdsaSigLen, 0);
+        err = test_pkey_sign_ecc(pkey, e, buf, sizeof(buf), ecdsaSig,
+                                 &ecdsaSigLen);
     }
     if (err == 0) {
         PRINT_MSG("Verify with OpenSSL");
-        err = test_pkey_verify(pkey, NULL, buf, sizeof(buf),
-                                     ecdsaSig, ecdsaSigLen, 0);
+        err = test_pkey_verify_ecc(pkey, NULL, buf, sizeof(buf), ecdsaSig,
+                                   ecdsaSigLen);
     }
 
     EVP_PKEY_free(pkey);
@@ -877,32 +895,32 @@ int test_ecdsa_p224_pkey(ENGINE *e, void *data)
     if (err == 0) {
         PRINT_MSG("Sign with OpenSSL");
         ecdsaSigLen = sizeof(ecdsaSig);
-        err = test_pkey_sign(pkey, NULL, buf, sizeof(buf), ecdsaSig,
-                                   &ecdsaSigLen, 0);
+        err = test_pkey_sign_ecc(pkey, NULL, buf, sizeof(buf), ecdsaSig,
+                                 &ecdsaSigLen);
     }
     if (err == 0) {
         PRINT_MSG("Verify with wolfengine");
-        err = test_pkey_verify(pkey, e, buf, sizeof(buf), ecdsaSig,
-                                     ecdsaSigLen, 0);
+        err = test_pkey_verify_ecc(pkey, e, buf, sizeof(buf), ecdsaSig,
+                                   ecdsaSigLen);
     }
     if (err == 0) {
         PRINT_MSG("Verify bad signature with wolfengine");
         ecdsaSig[1] ^= 0x80;
-        res = test_pkey_verify(pkey, e, buf, sizeof(buf), ecdsaSig,
-                                     ecdsaSigLen, 0);
+        res = test_pkey_verify_ecc(pkey, e, buf, sizeof(buf), ecdsaSig,
+                                   ecdsaSigLen);
         if (res != 1)
             err = 1;
     }
     if (err == 0) {
         PRINT_MSG("Sign with wolfengine");
         ecdsaSigLen = sizeof(ecdsaSig);
-        err = test_pkey_sign(pkey, e, buf, sizeof(buf), ecdsaSig,
-                                   &ecdsaSigLen, 0);
+        err = test_pkey_sign_ecc(pkey, e, buf, sizeof(buf), ecdsaSig,
+                                 &ecdsaSigLen);
     }
     if (err == 0) {
         PRINT_MSG("Verify with OpenSSL");
-        err = test_pkey_verify(pkey, NULL, buf, sizeof(buf),
-                                     ecdsaSig, ecdsaSigLen, 0);
+        err = test_pkey_verify_ecc(pkey, NULL, buf, sizeof(buf),
+                                   ecdsaSig, ecdsaSigLen);
     }
 
     EVP_PKEY_free(pkey);
@@ -932,32 +950,32 @@ int test_ecdsa_p256_pkey(ENGINE *e, void *data)
     if (err == 0) {
         PRINT_MSG("Sign with OpenSSL");
         ecdsaSigLen = sizeof(ecdsaSig);
-        err = test_pkey_sign(pkey, NULL, buf, sizeof(buf), ecdsaSig,
-                                   &ecdsaSigLen, 0);
+        err = test_pkey_sign_ecc(pkey, NULL, buf, sizeof(buf), ecdsaSig,
+                                 &ecdsaSigLen);
     }
     if (err == 0) {
         PRINT_MSG("Verify with wolfengine");
-        err = test_pkey_verify(pkey, e, buf, sizeof(buf), ecdsaSig,
-                                     ecdsaSigLen, 0);
+        err = test_pkey_verify_ecc(pkey, e, buf, sizeof(buf), ecdsaSig,
+                                   ecdsaSigLen);
     }
     if (err == 0) {
         PRINT_MSG("Verify bad signature with wolfengine");
         ecdsaSig[1] ^= 0x80;
-        res = test_pkey_verify(pkey, e, buf, sizeof(buf), ecdsaSig,
-                                     ecdsaSigLen, 0);
+        res = test_pkey_verify_ecc(pkey, e, buf, sizeof(buf), ecdsaSig,
+                                   ecdsaSigLen);
         if (res != 1)
             err = 1;
     }
     if (err == 0) {
         PRINT_MSG("Sign with wolfengine");
         ecdsaSigLen = sizeof(ecdsaSig);
-        err = test_pkey_sign(pkey, e, buf, sizeof(buf), ecdsaSig,
-                                   &ecdsaSigLen, 0);
+        err = test_pkey_sign_ecc(pkey, e, buf, sizeof(buf), ecdsaSig,
+                                 &ecdsaSigLen);
     }
     if (err == 0) {
         PRINT_MSG("Verify with OpenSSL");
-        err = test_pkey_verify(pkey, NULL, buf, sizeof(buf),
-                                     ecdsaSig, ecdsaSigLen, 0);
+        err = test_pkey_verify_ecc(pkey, NULL, buf, sizeof(buf),
+                                   ecdsaSig, ecdsaSigLen);
     }
 
     EVP_PKEY_free(pkey);
@@ -987,32 +1005,32 @@ int test_ecdsa_p384_pkey(ENGINE *e, void *data)
     if (err == 0) {
         PRINT_MSG("Sign with OpenSSL");
         ecdsaSigLen = sizeof(ecdsaSig);
-        err = test_pkey_sign(pkey, NULL, buf, sizeof(buf), ecdsaSig,
-                                   &ecdsaSigLen, 0);
+        err = test_pkey_sign_ecc(pkey, NULL, buf, sizeof(buf), ecdsaSig,
+                                 &ecdsaSigLen);
     }
     if (err == 0) {
         PRINT_MSG("Verify with wolfengine");
-        err = test_pkey_verify(pkey, e, buf, sizeof(buf), ecdsaSig,
-                                     ecdsaSigLen, 0);
+        err = test_pkey_verify_ecc(pkey, e, buf, sizeof(buf), ecdsaSig,
+                                   ecdsaSigLen);
     }
     if (err == 0) {
         PRINT_MSG("Verify bad signature with wolfengine");
         ecdsaSig[1] ^= 0x80;
-        res = test_pkey_verify(pkey, e, buf, sizeof(buf), ecdsaSig,
-                                     ecdsaSigLen, 0);
+        res = test_pkey_verify_ecc(pkey, e, buf, sizeof(buf), ecdsaSig,
+                                   ecdsaSigLen);
         if (res != 1)
             err = 1;
     }
     if (err == 0) {
         PRINT_MSG("Sign with wolfengine");
         ecdsaSigLen = sizeof(ecdsaSig);
-        err = test_pkey_sign(pkey, e, buf, sizeof(buf), ecdsaSig,
-                                   &ecdsaSigLen, 0);
+        err = test_pkey_sign_ecc(pkey, e, buf, sizeof(buf), ecdsaSig,
+                                 &ecdsaSigLen);
     }
     if (err == 0) {
         PRINT_MSG("Verify with OpenSSL");
-        err = test_pkey_verify(pkey, NULL, buf, sizeof(buf),
-                                     ecdsaSig, ecdsaSigLen, 0);
+        err = test_pkey_verify_ecc(pkey, NULL, buf, sizeof(buf),
+                                   ecdsaSig, ecdsaSigLen);
     }
 
     EVP_PKEY_free(pkey);
@@ -1042,32 +1060,32 @@ int test_ecdsa_p521_pkey(ENGINE *e, void *data)
     if (err == 0) {
         PRINT_MSG("Sign with OpenSSL");
         ecdsaSigLen = sizeof(ecdsaSig);
-        err = test_pkey_sign(pkey, NULL, buf, sizeof(buf), ecdsaSig,
-                                   &ecdsaSigLen, 0);
+        err = test_pkey_sign_ecc(pkey, NULL, buf, sizeof(buf), ecdsaSig,
+                                 &ecdsaSigLen);
     }
     if (err == 0) {
         PRINT_MSG("Verify with wolfengine");
-        err = test_pkey_verify(pkey, e, buf, sizeof(buf), ecdsaSig,
-                                     ecdsaSigLen, 0);
+        err = test_pkey_verify_ecc(pkey, e, buf, sizeof(buf), ecdsaSig,
+                                   ecdsaSigLen);
     }
     if (err == 0) {
         PRINT_MSG("Verify bad signature with wolfengine");
         ecdsaSig[1] ^= 0x80;
-        res = test_pkey_verify(pkey, e, buf, sizeof(buf), ecdsaSig,
-                                     ecdsaSigLen, 0);
+        res = test_pkey_verify_ecc(pkey, e, buf, sizeof(buf), ecdsaSig,
+                                   ecdsaSigLen);
         if (res != 1)
             err = 1;
     }
     if (err == 0) {
         PRINT_MSG("Sign with wolfengine");
         ecdsaSigLen = sizeof(ecdsaSig);
-        err = test_pkey_sign(pkey, e, buf, sizeof(buf), ecdsaSig,
-                                   &ecdsaSigLen, 0);
+        err = test_pkey_sign_ecc(pkey, e, buf, sizeof(buf), ecdsaSig,
+                                 &ecdsaSigLen);
     }
     if (err == 0) {
         PRINT_MSG("Verify with OpenSSL");
-        err = test_pkey_verify(pkey, NULL, buf, sizeof(buf),
-                                     ecdsaSig, ecdsaSigLen, 0);
+        err = test_pkey_verify_ecc(pkey, NULL, buf, sizeof(buf),
+                                   ecdsaSig, ecdsaSigLen);
     }
 
     EVP_PKEY_free(pkey);

--- a/test/unit.h
+++ b/test/unit.h
@@ -161,16 +161,18 @@ int test_digest_verify(EVP_PKEY *pkey, ENGINE *e, unsigned char *data,
                        unsigned char *sig, size_t sigLen, int padMode);
 
 int test_pkey_sign(EVP_PKEY *pkey, ENGINE *e, unsigned char *hash,
-                   size_t hashLen, unsigned char *sig,
-                   size_t *sigLen, int padMode);
-int test_pkey_verify(EVP_PKEY *pkey, ENGINE *e,
-                     unsigned char *hash, size_t hashLen,
-                     unsigned char *sig, size_t sigLen, int padMode);
+                   size_t hashLen, unsigned char *sig, size_t *sigLen,
+                   int padMode, const EVP_MD *rsaMd, const EVP_MD *rsaMgf1Md);
+int test_pkey_verify(EVP_PKEY *pkey, ENGINE *e, unsigned char *hash,
+                     size_t hashLen, unsigned char *sig, size_t sigLen,
+                     int padMode, const EVP_MD *rsaMd, const EVP_MD *rsaMgf1Md);
 
 int test_pkey_enc(EVP_PKEY *pkey, ENGINE *e, unsigned char *msg, size_t msgLen,
-                  unsigned char *ciphertext, size_t cipherLen, int padMode);
+                  unsigned char *ciphertext, size_t cipherLen, int padMode,
+                  const EVP_MD *rsaMd, const EVP_MD *rsaMgf1Md);
 int test_pkey_dec(EVP_PKEY *pkey, ENGINE *e, unsigned char *msg, size_t msgLen,
-                  unsigned char *ciphertext, size_t cipherLen, int padMode);
+                  unsigned char *ciphertext, size_t cipherLen, int padMode,
+                  const EVP_MD *rsaMd, const EVP_MD *rsaMgf1Md);
 #endif /* WE_HAVE_EVP_PKEY */
 
 #ifdef WE_HAVE_RSA
@@ -180,6 +182,12 @@ int test_rsa_direct_priv_dec(ENGINE *e, void *data);
 int test_rsa_direct_pub_enc(ENGINE *e, void *data);
 int test_rsa_direct_pub_dec(ENGINE *e, void *data);
 #ifdef WE_HAVE_EVP_PKEY
+int test_pkey_enc_rsa(EVP_PKEY *pkey, ENGINE *e, unsigned char *msg, size_t msgLen,
+                  unsigned char *ciphertext, size_t cipherLen, int padMode,
+                  const EVP_MD *rsaMd, const EVP_MD *rsaMgf1Md);
+int test_pkey_dec_rsa(EVP_PKEY *pkey, ENGINE *e, unsigned char *msg, size_t msgLen,
+                  unsigned char *ciphertext, size_t cipherLen, int padMode,
+                  const EVP_MD *rsaMd, const EVP_MD *rsaMgf1Md);
 int test_rsa_sign_verify_pkcs1(ENGINE *e, void *data);
 int test_rsa_sign_verify_no_pad(ENGINE *e, void *data);
 int test_rsa_sign_verify_pss(ENGINE *e, void *data);


### PR DESCRIPTION
- Use md and mdMGF1 members of we_Rsa for OAEP padding.
- Add support for control commands EVP_PKEY_CTRL_RSA_OAEP_MD,
  EVP_PKEY_CTRL_GET_RSA_OAEP_MD, EVP_PKEY_CTRL_RSA_MGF1_MD, and
  EVP_PKEY_CTRL_GET_RSA_MGF1_MD.
- Add RSA unit tests for OAEP and PSS that use different digests for label
  (OAEP), message hash (PSS), and MGF1 (both).