### PR TITLE
add unit test for AES-CMAC-192

### DIFF
--- a/src/we_internal.c
+++ b/src/we_internal.c
@@ -588,6 +588,8 @@ static int we_pkey(ENGINE *e, EVP_PKEY_METHOD **pkey, const int **nids,
     if (pkey == NULL) {
         /* Return a list of supported nids */
         ret = we_pkey_get_nids(nids);
+        WOLFENGINE_MSG(WE_LOG_ENGINE, "Returning %d supported public key NIDs",
+                       ret);
     }
     else {
         switch (nid) {

--- a/test/test_cmac.c
+++ b/test/test_cmac.c
@@ -153,6 +153,13 @@ int test_cmac_create(ENGINE *e, void *data)
                 EVP_aes_128_cbc());
     }
 
+    if (ret == 0) {
+        PRINT_MSG("Testing with a 192 bit KEY");
+        keySz = 24;
+        ret = test_cmac_create_helper(e, in, inSz, key, keySz,
+                EVP_aes_192_cbc());
+    }
+
     return ret;
 }
 


### PR DESCRIPTION
Fills a small gap in testing for AES-CMAC-192 unit tests.