### PR TITLE
HKDF: Add support (used with TLS 1.3)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -300,6 +300,7 @@ then
     AM_CFLAGS="$AM_CFLAGS -DWE_HAVE_HMAC -DWE_HAVE_EVP_PKEY"
 fi
 
+# TLS1 PRF
 AC_ARG_ENABLE([tls1-prf],
     [AS_HELP_STRING([--enable-tls1-prf],[Enable TLS1 PRF (default: enabled)])],
     [ ENABLED_TLS1_PRF=$enableval ],
@@ -314,6 +315,24 @@ then
         AC_MSG_WARN([--enable-tls1-prf ignored because OpenSSL doesn't have support for NID_tls1_prf.])
     else
         AM_CFLAGS="$AM_CFLAGS -DWE_HAVE_TLS1_PRF -DWE_HAVE_EVP_PKEY"
+    fi
+fi
+
+# HKDF (used in TLS 1.3)
+AC_ARG_ENABLE([hkdf],
+    [AS_HELP_STRING([--enable-hkdf],[Enable HKDF (default: enabled)])],
+    [ ENABLED_HKDF=$enableval ],
+    [ ENABLED_HKDF=yes ]
+    )
+
+if test "$ENABLED_HKDF" = "yes"
+then
+    if test "$OPENSSL_110_PLUS" = "no"
+    then
+        ENABLED_HKDF="no"
+        AC_MSG_WARN([--enable-hkdf ignored because OpenSSL doesn't have support for NID_hkdf.])
+    else
+        AM_CFLAGS="$AM_CFLAGS -DWE_HAVE_HKDF -DWE_HAVE_EVP_PKEY"
     fi
 fi
 
@@ -654,6 +673,7 @@ echo "   *  - SHA3-512:                $ENABLED_SHA3_512"
 echo "   * HMAC:                       $ENABLED_HMAC"
 echo "   * CMAC:                       $ENABLED_CMAC"
 echo "   * TLS1 PRF:                   $ENABLED_TLS1_PRF"
+echo "   * HKDF:                       $ENABLED_HKDF"
 echo "   * Random:                     $ENABLED_RAND"
 echo "   * RSA:                        $ENABLED_RSA"
 echo "   * DH:                         $ENABLED_DH"

--- a/include/wolfengine/we_internal.h
+++ b/include/wolfengine/we_internal.h
@@ -206,6 +206,13 @@ extern EVP_PKEY_METHOD *we_tls1_prf_method;
 int we_init_tls1_prf_meth(void);
 
 /*
+ * HKDF method.
+ */
+
+extern EVP_PKEY_METHOD *we_hkdf_method;
+int we_init_hkdf_meth(void);
+
+/*
  * DH method.
  */
 

--- a/include/wolfengine/we_openssl_bc.h
+++ b/include/wolfengine/we_openssl_bc.h
@@ -163,6 +163,16 @@ size_t EC_POINT_point2buf(const EC_GROUP *group, const EC_POINT *point,
 
 #if OPENSSL_VERSION_NUMBER < 0x10101000L
 
+#ifndef EVP_PKEY_HKDEF_MODE_EXTRACT_AND_EXPAND
+#define EVP_PKEY_HKDEF_MODE_EXTRACT_AND_EXPAND      0
+#endif
+#ifndef EVP_PKEY_HKDEF_MODE_EXTRACT_ONLY
+#define EVP_PKEY_HKDEF_MODE_EXTRACT_ONLY            1
+#endif
+#ifndef EVP_PKEY_HKDEF_MODE_EXPAND_ONLY
+#define EVP_PKEY_HKDEF_MODE_EXPAND_ONLY             2
+#endif
+
 const BIGNUM *DH_get0_p(const DH *dh);
 const BIGNUM *DH_get0_g(const DH *dh);
 const BIGNUM *DH_get0_q(const DH *dh);

--- a/openssl_patches/1.1.1b/tests/evp_extra_test_111b.patch
+++ b/openssl_patches/1.1.1b/tests/evp_extra_test_111b.patch
@@ -1,5 +1,5 @@
 diff --git a/test/evp_extra_test.c b/test/evp_extra_test.c
-index 918c3205..dceb96da 100644
+index 918c3205..e046f20c 100644
 --- a/test/evp_extra_test.c
 +++ b/test/evp_extra_test.c
 @@ -22,62 +22,135 @@
@@ -411,3 +411,20 @@ index 918c3205..dceb96da 100644
  };
  
  #ifndef OPENSSL_NO_EC
+@@ -940,12 +1093,13 @@ static int test_HKDF(void)
+     unsigned char out[20];
+     size_t outlen;
+     int i, ret = 0;
+-    unsigned char salt[] = "0123456789";
++    /* wolfSSL FIPS requires a minimum of 14 bytes for HMAC key. */
++    unsigned char salt[] = "01234567890123";
+     unsigned char key[] = "012345678901234567890123456789";
+     unsigned char info[] = "infostring";
+     const unsigned char expected[] = {
+-        0xe5, 0x07, 0x70, 0x7f, 0xc6, 0x78, 0xd6, 0x54, 0x32, 0x5f, 0x7e, 0xc5,
+-        0x7b, 0x59, 0x3e, 0xd8, 0x03, 0x6b, 0xed, 0xca
++        0xe7, 0x96, 0x86, 0x4c, 0xdf, 0x86, 0x12, 0x45, 0x7d, 0x2f, 0xc4, 0x9f,
++        0x54, 0xcf, 0xd4, 0x42, 0xaa, 0x19, 0xfa, 0x09
+     };
+     size_t expectedlen = sizeof(expected);
+ 

--- a/openssl_patches/1.1.1b/tests/evpkdf.txt_11b.patch
+++ b/openssl_patches/1.1.1b/tests/evpkdf.txt_11b.patch
@@ -1,0 +1,72 @@
+diff --git a/test/recipes/30-test_evp_data/evpkdf.txt b/test/recipes/30-test_evp_data/evpkdf.txt
+index 9a6cc283..d8b78730 100644
+--- a/test/recipes/30-test_evp_data/evpkdf.txt
++++ b/test/recipes/30-test_evp_data/evpkdf.txt
+@@ -71,19 +71,20 @@ Result = KDF_DERIVE_ERROR
+ 
+ Title = HKDF tests (from RFC5869 test vectors)
+ 
+-KDF = HKDF
+-Ctrl.md = md:SHA256
+-Ctrl.IKM = hexkey:0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
+-Ctrl.salt = hexsalt:000102030405060708090a0b0c
+-Ctrl.info = hexinfo:f0f1f2f3f4f5f6f7f8f9
+-Output = 3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865
+-
+-KDF = HKDF
+-Ctrl.mode = mode:EXTRACT_ONLY
+-Ctrl.md = md:SHA256
+-Ctrl.IKM = hexkey:0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
+-Ctrl.salt = hexsalt:000102030405060708090a0b0c
+-Output = 077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5
++# wolfSSL FIPS - salt needs to be at least 14.
++#KDF = HKDF
++#Ctrl.md = md:SHA256
++#Ctrl.IKM = hexkey:0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
++#Ctrl.salt = hexsalt:000102030405060708090a0b0c
++#Ctrl.info = hexinfo:f0f1f2f3f4f5f6f7f8f9
++#Output = 3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865
++
++#KDF = HKDF
++#Ctrl.mode = mode:EXTRACT_ONLY
++#Ctrl.md = md:SHA256
++#Ctrl.IKM = hexkey:0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
++#Ctrl.salt = hexsalt:000102030405060708090a0b0c
++#Output = 077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5
+ 
+ KDF = HKDF
+ Ctrl.mode = mode:EXPAND_ONLY
+@@ -135,19 +136,20 @@ Ctrl.IKM = hexkey:19ef24a32c717b167f33a91d6f648bdf96596776afdb6377ac434c1c293ccb
+ Ctrl.info = info:
+ Output = 8da4e775a563c18f715f802a063c5a31b8a11f5c5ee1879ec3454e5f3c738d2d9d201395faa4b61a96c8
+ 
+-KDF = HKDF
+-Ctrl.md = md:SHA1
+-Ctrl.IKM = hexkey:0b0b0b0b0b0b0b0b0b0b0b
+-Ctrl.salt = hexsalt:000102030405060708090a0b0c
+-Ctrl.info = hexinfo:f0f1f2f3f4f5f6f7f8f9
+-Output = 085a01ea1b10f36933068b56efa5ad81a4f14b822f5b091568a9cdd4f155fda2c22e422478d305f3f896
+-
+-KDF = HKDF
+-Ctrl.mode = mode:EXTRACT_ONLY
+-Ctrl.md = md:SHA1
+-Ctrl.IKM = hexkey:0b0b0b0b0b0b0b0b0b0b0b
+-Ctrl.salt = hexsalt:000102030405060708090a0b0c
+-Output = 9b6c18c432a7bf8f0e71c8eb88f4b30baa2ba243
++# wolfSSL FIPS - salt needs to be at least 14.
++#KDF = HKDF
++#Ctrl.md = md:SHA1
++#Ctrl.IKM = hexkey:0b0b0b0b0b0b0b0b0b0b0b
++#Ctrl.salt = hexsalt:000102030405060708090a0b0c
++#Ctrl.info = hexinfo:f0f1f2f3f4f5f6f7f8f9
++#Output = 085a01ea1b10f36933068b56efa5ad81a4f14b822f5b091568a9cdd4f155fda2c22e422478d305f3f896
++
++#KDF = HKDF
++#Ctrl.mode = mode:EXTRACT_ONLY
++#Ctrl.md = md:SHA1
++#Ctrl.IKM = hexkey:0b0b0b0b0b0b0b0b0b0b0b
++#Ctrl.salt = hexsalt:000102030405060708090a0b0c
++#Output = 9b6c18c432a7bf8f0e71c8eb88f4b30baa2ba243
+ 
+ KDF = HKDF
+ Ctrl.mode = mode:EXPAND_ONLY

--- a/openssl_patches/1.1.1b/tests/pkey_meth_kdf_test_111b.patch
+++ b/openssl_patches/1.1.1b/tests/pkey_meth_kdf_test_111b.patch
@@ -1,0 +1,47 @@
+diff --git a/test/pkey_meth_kdf_test.c b/test/pkey_meth_kdf_test.c
+index f2abcf3e..2b24b00e 100644
+--- a/test/pkey_meth_kdf_test.c
++++ b/test/pkey_meth_kdf_test.c
+@@ -31,7 +31,7 @@ static int test_kdf_tls1_prf(void)
+         TEST_error("EVP_PKEY_CTX_set_tls1_prf_md");
+         return 0;
+     }
+-    if (EVP_PKEY_CTX_set1_tls1_prf_secret(pctx, "secret", 6) <= 0) {
++    if (EVP_PKEY_CTX_set1_tls1_prf_secret(pctx, "secret of min 14", 16) <= 0) {
+         TEST_error("EVP_PKEY_CTX_set1_tls1_prf_secret");
+         return 0;
+     }
+@@ -46,8 +46,8 @@ static int test_kdf_tls1_prf(void)
+ 
+     {
+         const unsigned char expected[sizeof(out)] = {
+-            0x8e, 0x4d, 0x93, 0x25, 0x30, 0xd7, 0x65, 0xa0,
+-            0xaa, 0xe9, 0x74, 0xc3, 0x04, 0x73, 0x5e, 0xcc
++            0xb4, 0x19, 0x01, 0x10, 0x06, 0x49, 0x06, 0x23,
++            0xbe, 0x42, 0x98, 0xfe, 0x33, 0xb0, 0x76, 0xbb
+         };
+         if (!TEST_mem_eq(out, sizeof(out), expected, sizeof(expected))) {
+             return 0;
+@@ -72,11 +72,11 @@ static int test_kdf_hkdf(void)
+         TEST_error("EVP_PKEY_CTX_set_hkdf_md");
+         return 0;
+     }
+-    if (EVP_PKEY_CTX_set1_hkdf_salt(pctx, "salt", 4) <= 0) {
++    if (EVP_PKEY_CTX_set1_hkdf_salt(pctx, "salt of at least 14", 19) <= 0) {
+         TEST_error("EVP_PKEY_CTX_set1_hkdf_salt");
+         return 0;
+     }
+-    if (EVP_PKEY_CTX_set1_hkdf_key(pctx, "secret", 6) <= 0) {
++    if (EVP_PKEY_CTX_set1_hkdf_key(pctx, "secret of at least 14", 20) <= 0) {
+         TEST_error("EVP_PKEY_CTX_set1_hkdf_key");
+         return 0;
+     }
+@@ -91,7 +91,7 @@ static int test_kdf_hkdf(void)
+ 
+     {
+         const unsigned char expected[sizeof(out)] = {
+-            0x2a, 0xc4, 0x36, 0x9f, 0x52, 0x59, 0x96, 0xf8, 0xde, 0x13
++            0x73, 0xd2, 0xc0, 0x50, 0xe8, 0x88, 0xef, 0xd9, 0x05, 0xb5
+         };
+         if (!TEST_mem_eq(out, sizeof(out), expected, sizeof(expected))) {
+             return 0;

--- a/src/include.am
+++ b/src/include.am
@@ -12,6 +12,7 @@ libwolfengine_la_SOURCES += src/we_des3_cbc.c
 libwolfengine_la_SOURCES += src/we_dh.c
 libwolfengine_la_SOURCES += src/we_digest.c
 libwolfengine_la_SOURCES += src/we_ecc.c
+libwolfengine_la_SOURCES += src/we_hkdf.c
 libwolfengine_la_SOURCES += src/we_internal.c
 libwolfengine_la_SOURCES += src/we_logging.c
 libwolfengine_la_SOURCES += src/we_mac.c

--- a/src/we_digest.c
+++ b/src/we_digest.c
@@ -853,6 +853,7 @@ static int we_digest_cleanup(EVP_MD_CTX *ctx)
 
     digest = (we_Digest *)EVP_MD_CTX_md_data(ctx);
 
+    /* Free the digest unless no hash initialized. */
     if (digest != NULL) {
         rc = wc_HashFree(&digest->hash, digest->hashType);
         if (rc != 0) {

--- a/src/we_hkdf.c
+++ b/src/we_hkdf.c
@@ -1,0 +1,470 @@
+/* we_hkdf.c
+ *
+ * Copyright (C) 2006-2019 wolfSSL Inc.
+ *
+ * This file is part of wolfengine.
+ *
+ * wolfengine is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfengine is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#include <wolfengine/we_internal.h>
+
+#ifdef WE_HAVE_HKDF
+
+/* Maximum info length to use with HKDF. */
+#define WE_MAX_INFO_SIZE        1024
+
+/**
+ * Data used in HKDF operation.
+ */
+typedef struct we_Hkdf {
+    /** Mode to use with HKDF. */
+    int mode;
+    /** Digest to use with HKDF. */
+    int mdType;
+    /** Key for KDF. */
+    unsigned char *key;
+    /** Size of key in bytes. */
+    size_t keySz;
+    /** Salt for KDF. */
+    unsigned char *salt;
+    /** Size of salt in bytes. */
+    size_t saltSz;
+    /** Info for KDF. */
+    unsigned char info[WE_MAX_INFO_SIZE];
+    /** Size of info in bytes. */
+    size_t infoSz;
+} we_Hkdf;
+
+/**
+ * Initialize internal HKDF object.
+ *
+ * @param  ctx  [in]  PKEY context.
+ * @returns  1 on success and 0 on failure.
+ */
+static int we_hkdf_init(EVP_PKEY_CTX *ctx)
+{
+    int ret = 1;
+    we_Hkdf *hkdf;
+
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_hkdf_init");
+    WOLFENGINE_MSG_VERBOSE(WE_LOG_PK, "ARGS [ctx = %p]", ctx);
+
+    /* Allocate memory for internal HKDF object. */
+    hkdf = OPENSSL_zalloc(sizeof(*hkdf));
+    if (hkdf == NULL) {
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "OPENSSL_zalloc(hkdf)",
+                                   hkdf);
+        ret = 0;
+    }
+
+    if (ret == 1) {
+        /* Set internal HKDF object against PKEY context. */
+        EVP_PKEY_CTX_set_data(ctx, hkdf);
+    }
+
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_hkdf_init", ret);
+
+    return ret;
+}
+
+/**
+ * Cleanup internal HKDF object.
+ *
+ * @param  ctx  [in]  PKEY context.
+ */
+static void we_hkdf_cleanup(EVP_PKEY_CTX *ctx)
+{
+    we_Hkdf *hkdf;
+
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_hkdf_cleanup");
+    WOLFENGINE_MSG_VERBOSE(WE_LOG_PK, "ARGS [ctx = %p]", ctx);
+
+    /* Get internal HKDF object from PKEY context. */
+    hkdf = (we_Hkdf *)EVP_PKEY_CTX_get_data(ctx);
+    if (hkdf != NULL) {
+        /* Clear and free key. */
+        if (hkdf->key != NULL) {
+            OPENSSL_clear_free(hkdf->key, hkdf->keySz);
+        }
+        /* Clear and free salt. */
+        if (hkdf->salt != NULL) {
+            OPENSSL_free(hkdf->salt);
+        }
+        /* Clear info - sensitive data. */
+        OPENSSL_cleanse(hkdf->info, hkdf->infoSz);
+        /* Free internal HKDF object. */
+        OPENSSL_free(hkdf);
+    }
+
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_hkdf_cleanup", 1);
+}
+
+/**
+ * Derive the key from the key and info.
+ *
+ * @param  ctx    [in]      PKEY context.
+ * @param  key    [in]      Calculated key data.
+ * @param  keySz  [in,out]  On in, size of key data to calculate in bytes.
+ *                          On out, size of key data in bytes. When extracting
+ *                          only this will be the size of the digest.
+ * @returns  1 on success and 0 on failure.
+ */
+static int we_hkdf_derive(EVP_PKEY_CTX *ctx, unsigned char *key,
+                          size_t *keySz)
+{
+    we_Hkdf *hkdf;
+    int ret = 1;
+    int rc;
+
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_hkdf_derive");
+    WOLFENGINE_MSG_VERBOSE(WE_LOG_PK, "ARGS [ctx = %p, key = %p, keySz = %p]",
+                           ctx, key, keySz);
+
+    /* Get internal HKDF object from PKEY context. */
+    hkdf = (we_Hkdf *)EVP_PKEY_CTX_get_data(ctx);
+    /* Cannot get here without initialization succeeding. */
+
+    /* Check a digest was set - no default. */
+    if ((ret == 1) && (hkdf->mdType == 0)) {
+        WOLFENGINE_ERROR_MSG(WE_LOG_PK, "No digest from app.");
+        ret = 0;
+    }
+    /* Check a key was set - no point otherwise! */
+    if ((ret == 1) && (hkdf->keySz == 0)) {
+        WOLFENGINE_ERROR_MSG(WE_LOG_PK, "No key from app.");
+        ret = 0;
+    }
+    if ((ret == 1) && (hkdf->mode == EVP_PKEY_HKDEF_MODE_EXTRACT_AND_EXPAND)) {
+        rc = wc_HKDF(hkdf->mdType, hkdf->key, (word32)hkdf->keySz, hkdf->salt,
+            (word32)hkdf->saltSz, hkdf->info, (word32)hkdf->infoSz, key,
+            (word32)*keySz);
+        if (rc != 0) {
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_HKDF", rc);
+            ret = 0;
+        }
+    }
+    else if ((ret == 1) && (hkdf->mode == EVP_PKEY_HKDEF_MODE_EXTRACT_ONLY)) {
+        rc = wc_HKDF_Extract(hkdf->mdType, hkdf->salt, (word32)hkdf->saltSz,
+            hkdf->key, (word32)hkdf->keySz, key);
+        if (rc != 0) {
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_HKDF_Extract", rc);
+            ret = 0;
+        }
+        if (ret == 1) {
+            *keySz = (size_t)wc_HashGetDigestSize(hkdf->mdType);
+        }
+    }
+    else if ((ret == 1) && (hkdf->mode == EVP_PKEY_HKDEF_MODE_EXPAND_ONLY)) {
+        rc = wc_HKDF_Expand(hkdf->mdType, hkdf->key, (word32)hkdf->keySz,
+            hkdf->info, (word32)hkdf->infoSz, key, (word32)*keySz);
+        if (rc != 0) {
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_HKDF_Expand", rc);
+            ret = 0;
+        }
+    }
+
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_hkdf_derive", ret);
+
+    return ret;
+}
+
+/**
+ * Control function for HKDF.
+ *
+ * Supports:
+ *    EVP_PKEY_CTRL_HKDF_MODE - whether to do extract and expand or just one of.
+ *    EVP_PKEY_CTRL_HKDF_MD - set digest to use.
+ *    EVP_PKEY_CTRL_HKDF_KEY - set key to use in calculation.
+ *    EVP_PKEY_CTRL_HKDF_SALT - set salt to use in calculation.
+ *    EVP_PKEY_CTRL_HKDF_INFO - set/add info to use in calculation.
+ *
+ * @param  ctx    [in]  PKEY context.
+ * @param  type   [in]  Type of operation to perform.
+ * @param  num    [in]  Integer argument.
+ * @param  ptr    [in]  Pointer argument.
+ * @returns  1 on success and 0 on failure.
+ */
+static int we_hkdf_ctrl(EVP_PKEY_CTX *ctx, int type, int num, void *ptr)
+{
+    we_Hkdf *hkdf;
+    int ret = 1;
+    char errBuff[WOLFENGINE_MAX_LOG_WIDTH];
+
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_hkdf_ctrl");
+    WOLFENGINE_MSG_VERBOSE(WE_LOG_PK, "ARGS [ctx = %p, type = %d, num = %d, "
+                           "ptr = %p]", ctx, type, num, ptr);
+
+    /* Get internal HKDF object from PKEY context. */
+    hkdf = (we_Hkdf *)EVP_PKEY_CTX_get_data(ctx);
+    /* Cannot get here without initialization succeeding. */
+
+    switch (type) {
+    #if OPENSSL_VERSION_NUMBER >= 0x1010100fL
+        case EVP_PKEY_CTRL_HKDF_MODE:
+            WOLFENGINE_MSG(WE_LOG_PK, "type: EVP_PKEY_CTRL_HKDF_MODE");
+            /* num: Mode of operation for the HHKDF. */
+            if ((num != EVP_PKEY_HKDEF_MODE_EXTRACT_AND_EXPAND) &&
+                (num != EVP_PKEY_HKDEF_MODE_EXTRACT_ONLY) &&
+                (num != EVP_PKEY_HKDEF_MODE_EXPAND_ONLY)) {
+                /* Unsupported mode. */
+                XSNPRINTF(errBuff, sizeof(errBuff), "Unsupported mode %d",
+                          num);
+                WOLFENGINE_ERROR_MSG(WE_LOG_PK, errBuff);
+                ret = 0;
+            }
+            else {
+                hkdf->mode = num;
+            }
+            break;
+    #endif
+            
+        case EVP_PKEY_CTRL_HKDF_MD:
+            WOLFENGINE_MSG(WE_LOG_PK, "type: EVP_PKEY_CTRL_HKDF_MD");
+            /* ptr: EVP md object. */
+            /* Convert EVP_MD to  */
+            hkdf->mdType = we_nid_to_wc_hash_type(EVP_MD_type(ptr));
+            break;
+
+        case EVP_PKEY_CTRL_HKDF_KEY:
+            WOLFENGINE_MSG(WE_LOG_PK, "type: EVP_PKEY_CTRL_HKDF_KEY");
+            /* num: Number of bytes in buffer.
+             * ptr: Buffer holding key data. */
+            /* Number of bytes must be positive. */
+            if (num < 0) {
+                WOLFENGINE_ERROR_MSG(WE_LOG_PK, "Key size must be positive");
+                ret = 0;
+            }
+            if ((ret == 1) && (hkdf->key != NULL)) {
+                /* Setting key - dispose of old key. */
+                OPENSSL_clear_free(hkdf->key, hkdf->keySz);
+            }
+            if (ret == 1) {
+                /* Clear info as this is a new operation. */
+                OPENSSL_cleanse(hkdf->info, hkdf->infoSz);
+                hkdf->infoSz = 0;
+                /* Copy the key. */
+                hkdf->key = OPENSSL_memdup(ptr, num);
+                if (hkdf->key == NULL) {
+                    WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK, "OPENSSL_memdup(key)",
+                                               hkdf->key);
+                    ret = 0;
+                }
+                else {
+                    /* Store size of key. */
+                    hkdf->keySz  = num;
+                }
+            }
+            break;
+
+        case EVP_PKEY_CTRL_HKDF_SALT:
+            WOLFENGINE_MSG(WE_LOG_PK, "type: EVP_PKEY_CTRL_HKDF_SALT");
+            /* num: Number of bytes in buffer.
+             * ptr: Buffer holding salt data. */
+            /* Number of bytes must be positive. */
+            if (num < 0) {
+                WOLFENGINE_ERROR_MSG(WE_LOG_PK, "Seed size must be positive");
+                ret = 0;
+            }
+            if ((ret == 1) && (hkdf->salt != NULL)) {
+                /* Setting salt - dispose of old salt. */
+                OPENSSL_clear_free(hkdf->salt, hkdf->saltSz);
+                hkdf->salt = NULL;
+            }
+            if (ret == 1) {
+                /* Clear info as this is a new operation. */
+                OPENSSL_cleanse(hkdf->info, hkdf->infoSz);
+                hkdf->infoSz = 0;
+                /* Copy the salt if there not 0 length. */
+                if (num != 0) {
+                    hkdf->salt = OPENSSL_memdup(ptr, num);
+                    if (hkdf->salt == NULL) {
+                        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK,
+                            "OPENSSL_memdup(salt)", hkdf->key);
+                        ret = 0;
+                    }
+                }
+                if (ret == 1) {
+                    /* Store size of salt. */
+                    hkdf->saltSz  = num;
+                }
+            }
+            break;
+
+        case EVP_PKEY_CTRL_HKDF_INFO:
+            WOLFENGINE_MSG(WE_LOG_PK, "type: EVP_PKEY_CTRL_HKDF_INFO");
+            /* num: Number of bytes in buffer.
+             * ptr: Buffer holding info data. */
+            /* Valid to pass in empty buffer - ignored. */
+            if ((num != 0) && (ptr != NULL)) {
+                /* Ensure valid number - not negative and can fit. */
+                if ((num < 0) ||
+                        (num > (int)(WE_MAX_INFO_SIZE - hkdf->infoSz))) {
+                    WOLFENGINE_ERROR_MSG(WE_LOG_PK, "Info length invalid");
+                    ret = 0;
+                }
+                if (ret == 1) {
+                    /* Append bytes. */
+                    XMEMCPY(hkdf->info + hkdf->infoSz, ptr, num);
+                    hkdf->infoSz += num;
+                }
+            }
+            break;
+
+        default:
+            /* Unsupported type. */
+            XSNPRINTF(errBuff, sizeof(errBuff), "Unsupported ctrl type %d",
+                      type);
+            WOLFENGINE_ERROR_MSG(WE_LOG_PK, errBuff);
+            ret = 0;
+            break;
+    }
+
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_hkdf_ctrl", ret);
+
+    return ret;
+}
+
+/**
+ * Control function with string type for HKDF.
+ *
+ * Supports:
+ *    "mode" - operations to perform.
+ *    "md" - set digest to use.
+ *    "key" - string encoding of key.
+ *    "hexkey" - hex string of key.
+ *    "salt" - string encoding of salt.
+ *    "hexsalt" - hex string of salt.
+ *    "info" - string encoding of info.
+ *    "hexinfo" - hex string of info.
+ *
+ * @param  ctx    [in]  PKEY context.
+ * @param  type   [in]  Type of operation to perform.
+ * @param  value  [in]  Pointer argument.
+ * @returns  1 on success and 0 on failure.
+ */
+static int we_hkdf_ctrl_str(EVP_PKEY_CTX *ctx, const char *type,
+                                const char *value)
+{
+    int ret = 1;
+    we_Hkdf *hkdf;
+    char errBuff[WOLFENGINE_MAX_LOG_WIDTH];
+
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_hkdf_ctrl_str");
+    WOLFENGINE_MSG_VERBOSE(WE_LOG_PK, "ARGS [ctx = %p, type = %p, value = %p]",
+                           ctx, type, value);
+
+    if (value == NULL) {
+        WOLFENGINE_ERROR_MSG(WE_LOG_PK, "value == NULL");
+        ret = 0;
+    }
+#if OPENSSL_VERSION_NUMBER >= 0x1010100fL
+    else if (XSTRNCMP(type, "mode", 5) == 0) {
+        hkdf = (we_Hkdf *)EVP_PKEY_CTX_get_data(ctx);
+        /* Cannot get here without initialization succeeding. */
+        if (XSTRNCMP(value, "EXTRACT_AND_EXPAND", 19) == 0) {
+            hkdf->mode = EVP_PKEY_HKDEF_MODE_EXTRACT_AND_EXPAND;
+        }
+        else if (XSTRNCMP(value, "EXTRACT_ONLY", 13) == 0) {
+            hkdf->mode = EVP_PKEY_HKDEF_MODE_EXTRACT_ONLY;
+        }
+        else if (XSTRNCMP(value, "EXPAND_ONLY", 12) == 0) {
+            hkdf->mode = EVP_PKEY_HKDEF_MODE_EXPAND_ONLY;
+        }
+        else {
+            /* Unsupported string for value. */
+            XSNPRINTF(errBuff, sizeof(errBuff), "Unsupported mode string %s",
+                      value);
+            WOLFENGINE_ERROR_MSG(WE_LOG_PK, errBuff);
+            ret = 0;
+        }
+    }
+#endif
+    else if (XSTRNCMP(type, "md", 3) == 0) {
+        hkdf = (we_Hkdf *)EVP_PKEY_CTX_get_data(ctx);
+        /* Cannot get here without initialization succeeding. */
+        hkdf->mdType =
+            we_nid_to_wc_hash_type(EVP_MD_type(EVP_get_digestbyname(value)));
+    }
+    else if (XSTRNCMP(type, "key", 4) == 0) {
+        ret = EVP_PKEY_CTX_str2ctrl(ctx, EVP_PKEY_CTRL_HKDF_KEY, value);
+    }
+    else if (XSTRNCMP(type, "hexkey", 7) == 0) {
+        ret = EVP_PKEY_CTX_hex2ctrl(ctx, EVP_PKEY_CTRL_HKDF_KEY, value);
+    }
+    else if (XSTRNCMP(type, "salt", 5) == 0) {
+        ret = EVP_PKEY_CTX_str2ctrl(ctx, EVP_PKEY_CTRL_HKDF_SALT, value);
+    }
+    else if (XSTRNCMP(type, "hexsalt", 8) == 0) {
+        ret = EVP_PKEY_CTX_hex2ctrl(ctx, EVP_PKEY_CTRL_HKDF_SALT, value);
+    }
+    else if (XSTRNCMP(type, "info", 5) == 0) {
+        ret = EVP_PKEY_CTX_str2ctrl(ctx, EVP_PKEY_CTRL_HKDF_INFO, value);
+    }
+    else if (XSTRNCMP(type, "hexinfo", 8) == 0) {
+        ret = EVP_PKEY_CTX_hex2ctrl(ctx, EVP_PKEY_CTRL_HKDF_INFO, value);
+    }
+    else {
+        /* Unsupported string. */
+        XSNPRINTF(errBuff, sizeof(errBuff), "Unsupported ctrl type %s", type);
+        WOLFENGINE_ERROR_MSG(WE_LOG_PK, errBuff);
+        ret = 0;
+    }
+
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_hkdf_ctrl_str", ret);
+
+    return ret;
+}
+
+/** HKDF method using wolfSSL.  */
+EVP_PKEY_METHOD *we_hkdf_method;
+
+/**
+ * Initialize the HKDF method for use with the EVP_PKEY API.
+ *
+ * @return  1 on success and 0 on failure.
+ */
+int we_init_hkdf_meth(void)
+{
+    int ret = 1;
+
+    WOLFENGINE_ENTER(WE_LOG_PK, "we_init_hkdf_meth");
+
+    we_hkdf_method = EVP_PKEY_meth_new(EVP_PKEY_HKDF, 0);
+    if (we_hkdf_method == NULL) {
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PK,
+                                   "EVP_PKEY_meth_new", we_hkdf_method);
+        ret = 0;
+    }
+
+    if (ret == 1) {
+        EVP_PKEY_meth_set_init(we_hkdf_method, we_hkdf_init);
+        EVP_PKEY_meth_set_cleanup(we_hkdf_method, we_hkdf_cleanup);
+        EVP_PKEY_meth_set_ctrl(we_hkdf_method, we_hkdf_ctrl, we_hkdf_ctrl_str);
+        EVP_PKEY_meth_set_derive(we_hkdf_method, NULL, we_hkdf_derive);
+    }
+
+    if (ret == 0 && we_hkdf_method != NULL) {
+        EVP_PKEY_meth_free(we_hkdf_method);
+        we_hkdf_method = NULL;
+    }
+
+    WOLFENGINE_LEAVE(WE_LOG_PK, "we_init_hkdf_meth", ret);
+
+    return ret;
+}
+
+#endif /* WE_HAVE_HKDF */
+

--- a/src/we_internal.c
+++ b/src/we_internal.c
@@ -38,6 +38,9 @@ static const int we_pkey_nids[] = {
 #ifdef WE_HAVE_TLS1_PRF
     NID_tls1_prf,
 #endif /* WE_HAVE_TLS1_PRF */
+#ifdef WE_HAVE_HKDF
+    NID_hkdf,
+#endif /* WE_HAVE_HKDF */
 #ifdef WE_HAVE_RSA
     NID_rsaEncryption,
 #endif
@@ -611,6 +614,11 @@ static int we_pkey(ENGINE *e, EVP_PKEY_METHOD **pkey, const int **nids,
             *pkey = we_tls1_prf_method;
             break;
 #endif /* WE_HAVE_TLS1_PRF */
+#ifdef WE_HAVE_HKDF
+        case NID_hkdf:
+            *pkey = we_hkdf_method;
+            break;
+#endif /* WE_HAVE_HKDF */
 #ifdef WE_HAVE_RSA
         case NID_rsaEncryption:
             *pkey = we_rsa_pkey_method;
@@ -842,6 +850,13 @@ static int wolfengine_init(ENGINE *e)
     }
 #endif /* WE_HAVE_EVP_PKEY */
 #endif /* WE_HAVE_TLS1_PRF */
+#ifdef WE_HAVE_HKDF
+#ifdef WE_HAVE_EVP_PKEY
+    if (ret == 1) {
+        ret = we_init_hkdf_meth();
+    }
+#endif /* WE_HAVE_EVP_PKEY */
+#endif /* WE_HAVE_HKDF */
 #ifdef WE_HAVE_DH
 #ifdef WE_HAVE_EVP_PKEY
     if (ret == 1) {

--- a/test/include.am
+++ b/test/include.am
@@ -16,6 +16,7 @@ test_unit_test_SOURCES = \
 	test/test_dh.c \
 	test/test_digest.c \
 	test/test_ecc.c \
+	test/test_hkdf.c \
 	test/test_hmac.c \
 	test/test_logging.c \
 	test/test_pkey.c \

--- a/test/test_hkdf.c
+++ b/test/test_hkdf.c
@@ -1,0 +1,448 @@
+/* test_hkdf.c
+ *
+ * Copyright (C) 2019-2021 wolfSSL Inc.
+ *
+ * This file is part of wolfengine.
+ *
+ * wolfengine is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfengine is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#include "unit.h"
+
+#ifdef WE_HAVE_HKDF
+
+static int test_hkdf_calc(ENGINE *e, unsigned char *key, int keyLen,
+                          const EVP_MD *md, int mode)
+{
+    int err = 0;
+    EVP_PKEY_CTX *ctx = NULL;
+    unsigned char inKey[32] = { 0, };
+    unsigned char salt[32] = { 0, };
+    unsigned char info[32] = { 0, };
+    size_t len = keyLen;
+
+    (void)mode;
+
+    ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_HKDF, e);
+    if (ctx == NULL) {
+        err = 1;
+    }
+    if (err == 0) {
+        if (EVP_PKEY_derive_init(ctx) != 1) {
+            err = 1;
+        }
+    }
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L
+    if (err == 0) {
+        if (EVP_PKEY_CTX_hkdf_mode(ctx, mode) != 1) {
+            err = 1;
+        }
+    }
+#endif
+    if (err == 0) {
+        if (EVP_PKEY_CTX_set_hkdf_md(ctx, md) != 1) {
+            err = 1;
+        }
+    }
+    if (err == 0) {
+        if (EVP_PKEY_CTX_set1_hkdf_key(ctx, inKey, sizeof(inKey)) != 1) {
+            err = 1;
+        }
+    }
+    if ((err == 0) && (mode != EVP_PKEY_HKDEF_MODE_EXPAND_ONLY)) {
+        if (EVP_PKEY_CTX_set1_hkdf_salt(ctx, salt, sizeof(salt)) != 1) {
+            err = 1;
+        }
+    }
+    if ((err == 0) && (mode != EVP_PKEY_HKDEF_MODE_EXTRACT_ONLY)) {
+        if (EVP_PKEY_CTX_add1_hkdf_info(ctx, info, sizeof(info)) != 1) {
+            err = 1;
+        }
+    }
+    if (err == 0) {
+        if (EVP_PKEY_derive(ctx, key, &len) != 1) {
+            err = 1;
+        }
+    }
+
+    if ((err == 0) && (mode != EVP_PKEY_HKDEF_MODE_EXTRACT_ONLY)) {
+        if (len != (size_t)keyLen) {
+            err = 1;
+        }
+    }
+    else {
+        if (len != (size_t)EVP_MD_size(md)) {
+            err = 1;
+        }
+    }
+
+    EVP_PKEY_CTX_free(ctx);
+    return err;
+}
+
+static int test_hkdf_md(ENGINE *e, const EVP_MD *md, int mode)
+{
+    int err = 0;
+    unsigned char oKey[128];
+    unsigned char wKey[128];
+
+    PRINT_MSG("Calc with OpenSSL");
+    err = test_hkdf_calc(NULL, oKey, sizeof(oKey), md, mode);
+    if (err == 1) {
+        PRINT_MSG("FAILED OpenSSL");
+    }
+
+    if (err == 0) {
+        PRINT_MSG("Calc with wolfSSL");
+        err = test_hkdf_calc(e, wKey, sizeof(wKey), md, mode);
+        if (err == 1) {
+            PRINT_MSG("FAILED wolfSSL");
+        }
+    }
+
+
+    if ((err == 0) && (memcmp(oKey, wKey, sizeof(oKey)) != 0)) {
+        PRINT_BUFFER("OpenSSL key", oKey, sizeof(oKey));
+        PRINT_BUFFER("wolfSSL key", wKey, sizeof(wKey));
+        err = 1;
+    }
+
+    return err;
+}
+
+static int test_hkdf_str_calc(ENGINE *e, unsigned char *key, int keyLen,
+                                  const char *md, const char *mode)
+{
+    int err = 0;
+    EVP_PKEY_CTX *ctx = NULL;
+    const char* inKey = "0123456789abcf";
+    const char* salt = "Salt of at least 14 bytes";
+    const char* info = "Some info";
+    size_t len = keyLen;
+
+    ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_HKDF, e);
+    if (ctx == NULL) {
+        err = 1;
+    }
+    if (err == 0) {
+        if (EVP_PKEY_derive_init(ctx) != 1) {
+            err = 1;
+        }
+    }
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L
+    if (err == 0) {
+        if (EVP_PKEY_CTX_ctrl_str(ctx, "mode", mode) != 1) {
+            err = 1;
+        }
+    }
+#endif
+    if (err == 0) {
+        if (EVP_PKEY_CTX_ctrl_str(ctx, "md", md) != 1) {
+            err = 1;
+        }
+    }
+    if (err == 0) {
+        if (EVP_PKEY_CTX_ctrl_str(ctx, "key", inKey) != 1) {
+            err = 1;
+        }
+    }
+    if ((err == 0) && (strncmp(mode, "EXPAND_ONLY", 12) != 0)) {
+        if (EVP_PKEY_CTX_ctrl_str(ctx, "salt", salt) != 1) {
+            err = 1;
+        }
+    }
+    if ((err == 0) && (strncmp(mode, "EXTRACT_ONLY", 13) != 0)) {
+        if (EVP_PKEY_CTX_ctrl_str(ctx, "info", info) != 1) {
+            err = 1;
+        }
+    }
+    if (err == 0) {
+        if (EVP_PKEY_derive(ctx, key, &len) != 1) {
+            err = 1;
+        }
+    }
+
+    if ((err == 0) && (strncmp(mode, "EXTRACT_ONLY", 13) != 0)) {
+        if (len != (size_t)keyLen) {
+            err = 1;
+        }
+    }
+    else {
+        if (len != (size_t)EVP_MD_size(EVP_get_digestbyname(md))) {
+            err = 1;
+        }
+    }
+
+    EVP_PKEY_CTX_free(ctx);
+    return err;
+}
+
+static int test_hkdf_hexstr_calc(ENGINE *e, unsigned char *key, int keyLen,
+                                     const char *md, const char *mode)
+{
+    int err = 0;
+    EVP_PKEY_CTX *ctx = NULL;
+    const char* inKey = "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00";
+    const char* salt = "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00";
+    const char* info = "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00";
+    size_t len = keyLen;
+
+    ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_HKDF, e);
+    if (ctx == NULL) {
+        err = 1;
+    }
+    if (err == 0) {
+        if (EVP_PKEY_derive_init(ctx) != 1) {
+            err = 1;
+        }
+    }
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L
+    if (err == 0) {
+        if (EVP_PKEY_CTX_ctrl_str(ctx, "mode", mode) != 1) {
+            err = 1;
+        }
+    }
+#endif
+    if (err == 0) {
+        if (EVP_PKEY_CTX_ctrl_str(ctx, "md", md) != 1) {
+            err = 1;
+        }
+    }
+    if (err == 0) {
+        if (EVP_PKEY_CTX_ctrl_str(ctx, "hexkey", inKey) != 1) {
+            err = 1;
+        }
+    }
+    /* Set key twice to ensure no memory leak. */
+    if (err == 0) {
+        if (EVP_PKEY_CTX_ctrl_str(ctx, "hexkey", inKey) != 1) {
+            err = 1;
+        }
+    }
+    if ((err == 0) && (strncmp(mode, "EXPAND_ONLY", 12) != 0)) {
+        if (EVP_PKEY_CTX_ctrl_str(ctx, "hexsalt", salt) != 1) {
+            err = 1;
+        }
+    }
+    /* Set salt twice to ensure no memory leak. */
+    if ((err == 0) && (strncmp(mode, "EXPAND_ONLY", 12) != 0)) {
+        if (EVP_PKEY_CTX_ctrl_str(ctx, "hexsalt", salt) != 1) {
+            err = 1;
+        }
+    }
+    if ((err == 0) && (strncmp(mode, "EXTRACT_ONLY", 13) != 0)) {
+        if (EVP_PKEY_CTX_ctrl_str(ctx, "hexinfo", info) != 1) {
+            err = 1;
+        }
+    }
+    if (err == 0) {
+        if (EVP_PKEY_derive(ctx, key, &len) != 1) {
+            err = 1;
+        }
+    }
+
+    if ((err == 0) && (strncmp(mode, "EXTRACT_ONLY", 13) != 0)) {
+        if (len != (size_t)keyLen) {
+            err = 1;
+        }
+    }
+    else {
+        if (len != (size_t)EVP_MD_size(EVP_get_digestbyname(md))) {
+            err = 1;
+        }
+    }
+
+    EVP_PKEY_CTX_free(ctx);
+    return err;
+}
+
+static int test_hkdf_str_md(ENGINE *e, const char *md, const char *mode)
+{
+    int err = 0;
+    unsigned char oKey[128];
+    unsigned char wKey[128];
+
+    PRINT_MSG("Calc with strings OpenSSL");
+    err = test_hkdf_str_calc(NULL, oKey, sizeof(oKey), md, mode);
+    if (err == 1) {
+        PRINT_MSG("FAILED OpenSSL");
+    }
+
+    if (err == 0) {
+        PRINT_MSG("Calc with strings wolfSSL");
+        err = test_hkdf_str_calc(e, wKey, sizeof(wKey), md, mode);
+        if (err == 1) {
+            PRINT_MSG("FAILED wolfSSL");
+        }
+    }
+
+
+    if ((err == 0) && (memcmp(oKey, wKey, sizeof(oKey)) != 0)) {
+        PRINT_BUFFER("OpenSSL key", oKey, sizeof(oKey));
+        PRINT_BUFFER("wolfSSL key", wKey, sizeof(wKey));
+        err = 1;
+    }
+
+    if (err == 0) {
+        PRINT_MSG("Calc with hex strings OpenSSL");
+        err = test_hkdf_hexstr_calc(NULL, oKey, sizeof(oKey), md, mode);
+        if (err == 1) {
+            PRINT_MSG("FAILED OpenSSL");
+        }
+    }
+
+    if (err == 0) {
+        PRINT_MSG("Calc with hex strings wolfSSL");
+        err = test_hkdf_hexstr_calc(e, wKey, sizeof(wKey), md, mode);
+        if (err == 1) {
+            PRINT_MSG("FAILED wolfSSL");
+        }
+    }
+
+
+    if ((err == 0) && (memcmp(oKey, wKey, sizeof(oKey)) != 0)) {
+        PRINT_BUFFER("OpenSSL key", oKey, sizeof(oKey));
+        PRINT_BUFFER("wolfSSL key", wKey, sizeof(wKey));
+        err = 1;
+    }
+    return err;
+}
+
+static int test_hkdf_fail_calc(ENGINE *e)
+{
+    int err = 0;
+    EVP_PKEY_CTX *ctx = NULL;
+    unsigned char key[1] = { 0 };
+
+    if (EVP_PKEY_CTX_ctrl_str(NULL, "md", "sha256") == 1) {
+        err = 1;
+    }
+    if (err == 0) {
+        ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_HKDF, e);
+        if (ctx == NULL) {
+            err = 1;
+        }
+    }
+    if (err == 0) {
+        if (EVP_PKEY_derive_init(ctx) != 1) {
+            err = 1;
+        }
+    }
+    if (err == 0) {
+        /* Invalid control value. */
+        if (EVP_PKEY_CTX_ctrl(ctx, -1, EVP_PKEY_OP_DERIVE,
+                              EVP_PKEY_CTRL_TLS_SEED, 0, NULL) == 1) {
+            err = 1;
+        }
+    }
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L
+    if ((err == 0) && (e != NULL)) {
+        /* Invalid mode. */
+        if (EVP_PKEY_CTX_hkdf_mode(ctx, -1) == 1) {
+            err = 1;
+        }
+    }
+#endif
+    if (err == 0) {
+        /* Negative key length. */
+        if (EVP_PKEY_CTX_set1_hkdf_key(ctx, key, -1) == 1) {
+            err = 1;
+        }
+    }
+    if (err == 0) {
+        /* Negative salt length. */
+        if (EVP_PKEY_CTX_set1_hkdf_salt(ctx, key, -1) == 1) {
+            err = 1;
+        }
+    }
+    if (err == 0) {
+        /* Negative info length. */
+        if (EVP_PKEY_CTX_add1_hkdf_info(ctx, key, -1) == 1) {
+            err = 1;
+        }
+    }
+    if (err == 0) {
+        /* Invalid control type string. */
+        if (EVP_PKEY_CTX_ctrl_str(ctx, "invalid", "") == 1) {
+            err = 1;
+        }
+    }
+    if (err == 0) {
+        /* Empty digest string. */
+        if (EVP_PKEY_CTX_ctrl_str(ctx, "md", NULL) == 1) {
+            err = 1;
+        }
+    }
+
+    EVP_PKEY_CTX_free(ctx);
+    return err;
+}
+
+static int test_hkdf_fail(ENGINE *e)
+{
+    int err;
+
+    PRINT_MSG("Failure cases with OpenSSL");
+    err = test_hkdf_fail_calc(NULL);
+    if (err == 0) {
+        PRINT_MSG("Failure cases with wolfSSL");
+        err = test_hkdf_fail_calc(e);
+    }
+
+    return err;
+}
+
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L
+#define NUM_MODES     3
+#else
+#define NUM_MODES     1
+#endif
+
+int test_hkdf(ENGINE *e, void *data)
+{
+    int err = 0;
+    int i;
+    int mode[] = {
+        EVP_PKEY_HKDEF_MODE_EXTRACT_AND_EXPAND,
+        EVP_PKEY_HKDEF_MODE_EXTRACT_ONLY,
+        EVP_PKEY_HKDEF_MODE_EXPAND_ONLY
+    };
+    const char *modeStr[] = {
+        "EXTRACT_AND_EXPAND",
+        "EXTRACT_ONLY",
+        "EXPAND_ONLY"
+    };
+
+    (void)data;
+
+    for (i = 0; (err == 0) && (i < NUM_MODES); i++) {
+        err = test_hkdf_md(e, EVP_sha256(), mode[i]);
+        if (err == 0) {
+            err = test_hkdf_md(e, EVP_sha384(), mode[i]);
+        }
+    }
+    for (i = 0; (err == 0) && (i < NUM_MODES); i++) {
+        err = test_hkdf_str_md(e, "sha256", modeStr[i]);
+    }
+    if (err == 0) {
+        err = test_hkdf_fail(e);
+    }
+
+    return err;
+}
+
+#endif /* WE_HAVE_HKDF */
+
+

--- a/test/test_tls1_prf.c
+++ b/test/test_tls1_prf.c
@@ -110,7 +110,7 @@ static int test_tls1_prf_md(ENGINE *e, const EVP_MD *md)
 
     if ((err == 0) && (memcmp(oKey, wKey, sizeof(oKey)) != 0)) {
         PRINT_BUFFER("OpenSSL key", oKey, sizeof(oKey));
-       PRINT_BUFFER("wolfSSL key", wKey, sizeof(wKey));
+        PRINT_BUFFER("wolfSSL key", wKey, sizeof(wKey));
         err = 1;
     }
 

--- a/test/unit.c
+++ b/test/unit.c
@@ -88,6 +88,9 @@ TEST_CASE test_case[] = {
 #ifdef WE_HAVE_TLS1_PRF
     TEST_DECL(test_tls1_prf, NULL),
 #endif
+#ifdef WE_HAVE_HKDF
+    TEST_DECL(test_hkdf, NULL),
+#endif
 #ifdef WE_HAVE_DES3CBC
     TEST_DECL(test_des3_cbc, NULL),
     TEST_DECL(test_des3_cbc_stream, NULL),

--- a/test/unit.h
+++ b/test/unit.h
@@ -115,6 +115,10 @@ int test_hmac_create(ENGINE *e, void *data);
 int test_tls1_prf(ENGINE *e, void *data);
 #endif
 
+#ifdef WE_HAVE_HKDF
+int test_hkdf(ENGINE *e, void *data);
+#endif
+
 #ifdef WE_HAVE_DES3CBC
 int test_des3_cbc(ENGINE *e, void *data);
 int test_des3_cbc_stream(ENGINE *e, void *data);


### PR DESCRIPTION
Add implementation and test.
Include OpenSSL unit test of KDFs through EVP_PKEY.