### PR TITLE
Return an error if SHA-1 used with RSA signing in FIPS mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ make
 sudo make install
 ```
 
-Add `--enable-fips=v2` to the configure command above if building from a FIPS bundle and not the git repository.
+Remove `-DWOLFSSL_PSS_LONG_SALT -DWOLFSSL_PSS_SALT_LEN_DISCOVER` and add `--enable-fips=v2` to the configure command above if building from a FIPS bundle and not the git repository.
 
 ### wolfEngine
 

--- a/openssl_patches/1.1.1b/tests/fips/80-test_cms.t_111b.patch
+++ b/openssl_patches/1.1.1b/tests/fips/80-test_cms.t_111b.patch
@@ -1,0 +1,13 @@
+diff --git a/test/recipes/80-test_cms.t b/test/recipes/80-test_cms.t
+index f038bea31d..e81a34d4d4 100644
+--- a/test/recipes/80-test_cms.t
++++ b/test/recipes/80-test_cms.t
+@@ -108,7 +108,7 @@ my @smime_pkcs7_tests = (
+     ],
+ 
+     [ "signed content S/MIME format, RSA key SHA1",
+-      [ "-sign", "-in", $smcont, "-md", "sha1",
++      [ "-sign", "-in", $smcont, "-md", "sha256",
+ 	"-certfile", catfile($smdir, "smroot.pem"),
+ 	"-signer", catfile($smdir, "smrsa1.pem"), "-out", "test.cms" ],
+       [ "-verify", "-in", "test.cms",

--- a/openssl_patches/1.1.1b/tests/fips/80-test_ssl_old.t_111b.patch
+++ b/openssl_patches/1.1.1b/tests/fips/80-test_ssl_old.t_111b.patch
@@ -1,0 +1,15 @@
+diff --git a/test/recipes/80-test_ssl_old.t b/test/recipes/80-test_ssl_old.t
+index 377bf090ba..ec10448c55 100644
+--- a/test/recipes/80-test_ssl_old.t
++++ b/test/recipes/80-test_ssl_old.t
+@@ -32,8 +32,8 @@ my $no_anydtls = alldisabled(available_protocols("dtls"));
+ plan skip_all => "No SSL/TLS/DTLS protocol is support by this OpenSSL build"
+     if $no_anytls && $no_anydtls;
+ 
+-my $digest = "-sha1";
+-my @reqcmd = ("openssl", "req");
++my $digest = "-sha256";
++my @reqcmd = ("openssl", "req", $digest);
+ my @x509cmd = ("openssl", "x509", $digest);
+ my @verifycmd = ("openssl", "verify");
+ my @gendsacmd = ("openssl", "gendsa");

--- a/openssl_patches/1.1.1b/tests/fips/evppkey.txt_111b.patch
+++ b/openssl_patches/1.1.1b/tests/fips/evppkey.txt_111b.patch
@@ -1,0 +1,45 @@
+diff --git a/test/recipes/30-test_evp_data/evppkey.txt b/test/recipes/30-test_evp_data/evppkey.txt
+index 736e0ce4d3..4ebbc27d50 100644
+--- a/test/recipes/30-test_evp_data/evppkey.txt
++++ b/test/recipes/30-test_evp_data/evppkey.txt
+@@ -134,6 +134,7 @@ Sign = RSA-2048
+ Ctrl = digest:SHA1
+ Input = "0123456789ABCDEF1234"
+ Output = c09d402423cbf233d26cae21f954547bc43fe80fd41360a0336cfdbe9aedad05bef6fd2eaee6cd60089a52482d4809a238149520df3bdde4cb9e23d9307b05c0a6f327052325a29adf2cc95b66523be7024e2a585c3d4db15dfbe146efe0ecdc0402e33fe5d40324ee96c5c3edd374a15cdc0f5d84aa243c0f07e188c6518fbfceae158a9943be398e31097da81b62074f626eff738be6160741d5a26957a482b3251fd85d8df78b98148459de10aa93305dbb4a5230aa1da291a9b0e481918f99b7638d72bb687f97661d304ae145d64a474437a4ef39d7b8059332ddeb07e92bf6e0e3acaf8afedc93795e4511737ec1e7aab6d5bc9466afc950c1c17b48ad
++Result = KEYOP_LENGTH_ERROR
+ 
+ Verify = RSA-2048
+ Ctrl = digest:SHA1
+@@ -162,14 +163,14 @@ Sign = RSA-2048
+ Ctrl = digest:SHA1
+ Input = "0123456789ABCDEF12345"
+ Output = 00
+-Result = KEYOP_ERROR
++Result = KEYOP_LENGTH_ERROR
+ 
+ # Digest too short
+ Sign = RSA-2048
+ Ctrl = digest:SHA1
+ Input = "0123456789ABCDEF12345"
+ Output = 00
+-Result = KEYOP_ERROR
++Result = KEYOP_LENGTH_ERROR
+ 
+ # Mismatched digest
+ Verify = RSA-2048
+@@ -17402,6 +17403,7 @@ DigestSign = SHA1
+ Key = RSA-2048
+ Input = "Hello World"
+ Output = 3da3ca2bdd1b23a231b0e3c49d95d5959f9398c27a1e534c7e6baf1d2682304d3b6b229385b1edf483f5ef6f9b35bf10c519a302bb2f79c564e1a59ba71aa2fa36df96c942c43e8d9bd4702b5f61c12a078ae2b34d0de221fc8f9f936b79a67c89d11ba5da8c63a1370d0e824c6b661123e9b58b143ff533cf362cbdad70e65b419a6d45723bf22db3c76bb8f5337c5c5c93cb6f38b30d0c835b54c23405ca4217dd0b755f3712ebad285d9e0c02655f6ce5ce6fed78f3c81843de325f628055eef57f280dee0c3170050137ee599b9ab7f2b5d3c5f831777ea05a5eb097c70bad1a7214dadae12d7960bb9425390c7d25a79985e1e3c28ad422ff93c808f4b5
++Result = DIGESTSIGNFINAL_LENGTH_ERROR
+ 
+ DigestSign = SHA256
+ Key = RSA-2048
+@@ -17455,6 +17457,7 @@ OneShotDigestSign = SHA1
+ Key = RSA-2048
+ Input = "Hello World"
+ Output = 3da3ca2bdd1b23a231b0e3c49d95d5959f9398c27a1e534c7e6baf1d2682304d3b6b229385b1edf483f5ef6f9b35bf10c519a302bb2f79c564e1a59ba71aa2fa36df96c942c43e8d9bd4702b5f61c12a078ae2b34d0de221fc8f9f936b79a67c89d11ba5da8c63a1370d0e824c6b661123e9b58b143ff533cf362cbdad70e65b419a6d45723bf22db3c76bb8f5337c5c5c93cb6f38b30d0c835b54c23405ca4217dd0b755f3712ebad285d9e0c02655f6ce5ce6fed78f3c81843de325f628055eef57f280dee0c3170050137ee599b9ab7f2b5d3c5f831777ea05a5eb097c70bad1a7214dadae12d7960bb9425390c7d25a79985e1e3c28ad422ff93c808f4b5
++Result = DIGESTSIGN_LENGTH_ERROR
+ 
+ Title = ED25519 tests from RFC8032
+ 

--- a/src/we_hkdf.c
+++ b/src/we_hkdf.c
@@ -116,7 +116,7 @@ static void we_hkdf_cleanup(EVP_PKEY_CTX *ctx)
  * Derive the key from the key and info.
  *
  * @param  ctx    [in]      PKEY context.
- * @param  key    [in]      Calculated key data.
+ * @param  key    [out]     Calculated key data.
  * @param  keySz  [in,out]  On in, size of key data to calculate in bytes.
  *                          On out, size of key data in bytes. When extracting
  *                          only this will be the size of the digest.

--- a/test/unit.c
+++ b/test/unit.c
@@ -167,6 +167,7 @@ TEST_CASE test_case[] = {
 #endif /* OPENSSL_VERSION_NUMBER < 0x10100000L */
 #ifdef WE_HAVE_EVP_PKEY
 #ifdef WE_HAVE_RSA
+    TEST_DECL(test_rsa_sign_sha1, NULL),
     TEST_DECL(test_rsa_sign_verify_pkcs1, NULL),
     TEST_DECL(test_rsa_sign_verify_no_pad, NULL),
     TEST_DECL(test_rsa_sign_verify_pss, NULL),

--- a/test/unit.h
+++ b/test/unit.h
@@ -217,6 +217,7 @@ int test_pkey_enc_rsa(EVP_PKEY *pkey, ENGINE *e, unsigned char *msg, size_t msgL
 int test_pkey_dec_rsa(EVP_PKEY *pkey, ENGINE *e, unsigned char *msg, size_t msgLen,
                   unsigned char *ciphertext, size_t cipherLen, int padMode,
                   const EVP_MD *rsaMd, const EVP_MD *rsaMgf1Md);
+int test_rsa_sign_sha1(ENGINE *e, void *data);
 int test_rsa_sign_verify_pkcs1(ENGINE *e, void *data);
 int test_rsa_sign_verify_no_pad(ENGINE *e, void *data);
 int test_rsa_sign_verify_pss(ENGINE *e, void *data);


### PR DESCRIPTION
Customer pointed out that we don't allow SHA-1 to be used when doing an RSA signing operation, according to our FIPS security policy. Verify is ok, though.