### PR TITLE
PBES: add PBKDF implementations that call into wolfCrypt

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ make
 sudo make install
 ```
 
+Add `--enable-pwdbased` to the configure command above if PKCS#12 is used in OpenSSL.
+
 Remove `-DWOLFSSL_PSS_LONG_SALT -DWOLFSSL_PSS_SALT_LEN_DISCOVER` and add `--enable-fips=v2` to the configure command above if building from a FIPS bundle and not the git repository.
 
 ### wolfEngine
@@ -83,8 +85,7 @@ make check
 ```
 
 * To build wolfEngine in single-threaded mode, add `--enable-singlethreaded` to the configure command.
-* AES-GCM is disabled by default because of the code changes required to OpenSSL. To enable it, add `--enable-aesgcm`.
-* AES-CCM is disabled by default for the same reason. To enable it, add `--enable-aesccm`.
+* To build wolfEngine with PBES support (used with PKCS #12), add `--enable-pbe`. Note: wolfSSL must have been configured with `--enable-pwdbased`.
 * To disable support for loading wolfEngine dynamically, add `--disable-dynamic-engine`.
 * To build a static version of wolfEngine, add `--enable-static`.
 * To use a custom user_settings.h file to override the defines produced by `./configure`, add `--enable-usersettings` and place a user_settings.h file with the defines you want in the include directory. See the root of the project for an example user_settings.h.

--- a/configure.ac
+++ b/configure.ac
@@ -589,6 +589,18 @@ then
 fi
 
 
+AC_ARG_ENABLE([pbe],
+    [AS_HELP_STRING([--enable-pbe],[Enable PBE (default: disabled)])],
+    [ ENABLED_PBE=$enableval ],
+    [ ENABLED_PBE=no ]
+    )
+
+if test "$ENABLED_PBE" = "yes"
+then
+    AM_CFLAGS="$AM_CFLAGS -DWE_HAVE_PBE"
+fi
+
+
 # Check enable options
 if test "$ENABLED_DIGEST" = "yes"
 then
@@ -694,6 +706,7 @@ echo "   *  - P-224:                   $ENABLED_EC_P224"
 echo "   *  - P-256:                   $ENABLED_EC_P256"
 echo "   *  - P-384:                   $ENABLED_EC_P384"
 echo "   *  - P-521:                   $ENABLED_EC_P521"
+echo "   * PBE:                        $ENABLED_PBE"
 echo ""
 echo "---"
 

--- a/include/wolfengine/we_internal.h
+++ b/include/wolfengine/we_internal.h
@@ -57,6 +57,7 @@
 #if OPENSSL_VERSION_NUMBER >= 0x10101000L
 #include <openssl/cmac.h>
 #endif
+#include <openssl/pkcs12.h>
 
 #include <wolfssl/options.h>
 #include <wolfssl/wolfcrypt/hash.h>
@@ -73,10 +74,22 @@
 #include <wolfssl/wolfcrypt/asn_public.h>
 #include <wolfssl/wolfcrypt/ecc.h>
 #include <wolfssl/wolfcrypt/random.h>
+#include <wolfssl/wolfcrypt/pwdbased.h>
 
 #include <wolfengine/we_openssl_bc.h>
 
 #include <wolfengine/we_logging.h>
+
+#if defined(__IAR_SYSTEMS_ICC__) || defined(__GNUC__)
+    /* Function is a printf style function. Pretend parameter is string literal.
+     *
+     * @param s  [in]  Index of string literal. Index from 1.
+     * @param v  [in]  Index of first argument to check. 0 means don't.
+     */
+    #define WE_PRINTF_FUNC(s, v)  __attribute__((__format__ (__printf__, s, v)))
+#else
+    #define WE_PRINTF_FUNC(s, v)
+#endif
 
 #if defined(HAVE_FIPS) || defined(HAVE_FIPS_VERSION)
 /*
@@ -289,6 +302,14 @@ extern EVP_PKEY_METHOD *we_ec_p384_method;
 extern EVP_PKEY_METHOD *we_ec_p521_method;
 int we_init_ecc_meths(void);
 int we_init_ec_key_meths(void);
+
+/*
+ * PBE method
+ */
+
+#ifdef WE_HAVE_PBE
+int we_init_pbe_keygen(void);
+#endif
 
 int wolfengine_bind(ENGINE *e, const char *id);
 

--- a/include/wolfengine/we_logging.h
+++ b/include/wolfengine/we_logging.h
@@ -85,6 +85,7 @@ enum wolfEngine_LogComponents {
     WE_LOG_PK     = 0x0010,  /* public key algorithms (RSA, ECC) */
     WE_LOG_KE     = 0x0020,  /* key agreement (DH, ECDH) */
     WE_LOG_ENGINE = 0x0040,  /* all engine specific logs */
+    WE_LOG_PBE    = 0x0080,  /* password base encryption algorithms */
 
     /* log all compoenents */
     WE_LOG_COMPONENTS_ALL = (WE_LOG_RNG
@@ -93,7 +94,8 @@ enum wolfEngine_LogComponents {
                            | WE_LOG_CIPHER
                            | WE_LOG_PK
                            | WE_LOG_KE
-                           | WE_LOG_ENGINE),
+                           | WE_LOG_ENGINE
+                           | WE_LOG_PBE),
 
     /* default compoenents logged */
     WE_LOG_COMPONENTS_DEFAULT = WE_LOG_COMPONENTS_ALL

--- a/scripts/openssl-unit-tests.sh
+++ b/scripts/openssl-unit-tests.sh
@@ -290,6 +290,7 @@ build_wolfssl() {
         ./configure LDFLAGS="-L$OPENSSL_SOURCE $WOLFENGINE_EXTRA_LDFLAGS" \
                     CPPFLAGS="$WOLFENGINE_EXTRA_CPPFLAGS" \
                     --with-openssl=$OPENSSL_SOURCE \
+                    $WOLFENGINE_EXTRA_OPTS \
                     --enable-debug 2>&1 | tee -a $LOGFILE
         if [ "${PIPESTATUS[0]}" != 0 ]; then
             printf "config failed\n"

--- a/src/include.am
+++ b/src/include.am
@@ -17,6 +17,7 @@ libwolfengine_la_SOURCES += src/we_internal.c
 libwolfengine_la_SOURCES += src/we_logging.c
 libwolfengine_la_SOURCES += src/we_mac.c
 libwolfengine_la_SOURCES += src/we_openssl_bc.c
+libwolfengine_la_SOURCES += src/we_pbe.c
 libwolfengine_la_SOURCES += src/we_random.c
 libwolfengine_la_SOURCES += src/we_rsa.c
 libwolfengine_la_SOURCES += src/we_tls_prf.c

--- a/src/we_internal.c
+++ b/src/we_internal.c
@@ -919,6 +919,11 @@ static int wolfengine_init(ENGINE *e)
     }
 #endif
 #endif
+#ifdef WE_HAVE_PBE
+    if (ret == 1) {
+        we_init_pbe_keygen();
+    }
+#endif
 
 #endif
 

--- a/src/we_logging.c
+++ b/src/we_logging.c
@@ -182,6 +182,7 @@ static void wolfengine_log(const int logLevel, const int component,
  * @param fmt   [IN] Log message format string.
  * @param vargs [IN] Variable arguments, used with format string, fmt.
  */
+WE_PRINTF_FUNC(3, 0)
 static void wolfengine_msg_internal(int component, int logLevel,
                                     const char* fmt, va_list vlist)
 {
@@ -200,6 +201,7 @@ static void wolfengine_msg_internal(int component, int logLevel,
  * @param fmt   [IN] Log message format string.
  * @param vargs [IN] Variable arguments, used with format string, fmt.
  */
+WE_PRINTF_FUNC(2, 3)
 void WOLFENGINE_MSG(int component, const char* fmt, ...)
 {
     va_list vlist;
@@ -215,6 +217,7 @@ void WOLFENGINE_MSG(int component, const char* fmt, ...)
  * @param fmt   [IN] Log message format string.
  * @param vargs [IN] Variable arguments, used with format string, fmt.
  */
+WE_PRINTF_FUNC(2, 3)
 void WOLFENGINE_MSG_VERBOSE(int component, const char* fmt, ...)
 {
     va_list vlist;

--- a/src/we_pbe.c
+++ b/src/we_pbe.c
@@ -1,0 +1,552 @@
+/* we_pbe_keygen.c
+ *
+ * Copyright (C) 2019-2021 wolfSSL Inc.
+ *
+ * This file is part of wolfEngine.
+ *
+ * wolfEngine is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfengine is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#include <wolfengine/we_internal.h>
+
+#ifdef WE_HAVE_PBE
+
+#ifndef NO_PWDBASED
+/**
+ * Convert the OpenSSL HMAC NID to a wolfCrypt hash type.
+ *
+ * @param  nid  [in]  OpenSSL HMAC NID.
+ * @returns  wolfCrypt hash type on success and 0 on failure.
+ */
+static int we_hmac_to_wc_hash(int nid)
+{
+    int hashType;
+
+    switch (nid) {
+    #ifndef NO_MD5
+        case NID_hmacWithMD5:
+        case NID_hmac_md5:
+            hashType = WC_MD5;
+            break;
+    #endif
+    #ifndef NO_SHA
+        case NID_hmacWithSHA1:
+        case NID_hmac_sha1:
+            hashType = WC_SHA;
+            break;
+    #endif
+    #ifdef WOLFSSL_SHA224
+        case NID_hmacWithSHA224:
+            hashType = WC_SHA224;
+            break;
+    #endif
+    #ifndef NO_SHA256
+        case NID_hmacWithSHA256:
+            hashType = WC_SHA256;
+            break;
+    #endif
+    #ifdef WOLFSSL_SHA384
+        case NID_hmacWithSHA384:
+            hashType = WC_SHA384;
+            break;
+    #endif
+    #ifdef WOLFSSL_SHA512
+        case NID_hmacWithSHA512:
+            hashType = WC_SHA512;
+            break;
+    #endif
+        /* TODO: OpenSSL also has -
+         *     NID_hmacWithSHA512_224
+         *     NID_hmacWithSHA512_256
+         */
+        default:
+            /* Unsupported hash algorithm in wolfCrypt. */
+            WOLFENGINE_ERROR_MSG(WE_LOG_PBE, "Hash not supported");
+            hashType = 0;
+            break;
+    }
+
+    return hashType;
+}
+
+/**
+ * Derive the key with PBKDF2 and BER encoded parameters using the password.
+ *
+ * @param  ctx        [in]  Cipher context to set up with a key.
+ * @param  passwd     [in]  Password to derive key from.
+ * @param  passwdLen  [in]  Length of password.
+ * @param  param      [in]  BER encoded PBKDF2 parameters
+ * @param  cipher     [in]  Cipher to use for encryption. (ignored)
+ * @param  md         [in]  Hash algorithm to use in derivation. (ignored)
+ * @param  en_de      [in]  Setup cipher for encryption or decryption.
+ * @returns  1 on success and 0 on failure.
+ */
+static int we_pbkdf2_keygen(EVP_CIPHER_CTX *ctx, const char *passwd,
+    int passwdLen, ASN1_TYPE *param, const EVP_CIPHER *cipher, const EVP_MD *md,
+    int en_de)
+{
+    int ret = 1;
+    int rc;
+    unsigned char key[EVP_MAX_KEY_LENGTH];
+    int kLen;
+    int kdfKeyLen;
+    PBKDF2PARAM *kdf = NULL;
+    int prfNid = NID_hmacWithSHA1;
+    int iterations;
+    unsigned char *salt;
+    int sLen;
+    int hashType;
+
+    /* Cipher already set.  */
+    (void)cipher;
+    /* Digest comes from BER encoded parameters.  */
+    (void)md;
+
+    WOLFENGINE_ENTER(WE_LOG_PBE, "we_pbkdf2_keygen");
+    WOLFENGINE_MSG_VERBOSE(WE_LOG_PBE, "ARGS [ctx = %p, passwd = %p, "
+        "passwdLen = %d, param = %p, cipher = %p, md = %p, en_de = %d]", ctx,
+        passwd, passwdLen, param, cipher, md, en_de);
+
+    /* Get the key length to derive. */
+    kLen = (int)EVP_CIPHER_CTX_key_length(ctx);
+    if (kLen > EVP_MAX_KEY_LENGTH) {
+        WOLFENGINE_ERROR_FUNC(WE_LOG_PBE, "EVP_CIPHER_CTX_key_length", kLen);
+        ret = 0;
+    }
+
+    if (ret == 1) {
+        /* Decode the PBKDF2 parameters. */
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+        kdf = ASN1_TYPE_unpack_sequence(ASN1_ITEM_rptr(PBKDF2PARAM), param);
+#else
+        const unsigned char *pBuf = param->value.sequence->data;
+        int pLen = param->value.sequence->length;
+        kdf = d2i_PBKDF2PARAM(NULL, &pBuf, pLen);
+#endif /* OPENSSL_VERSION_NUMBER >= 0x10100000L */
+        if (kdf == NULL) {
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PBE, "ASN1_TYPE_unpack_sequence",
+                                       kdf);
+            ret = 0;
+        }
+    }
+    /* Validate salt type. */
+    if ((ret == 1) && (kdf->salt->type != V_ASN1_OCTET_STRING)) {
+        WOLFENGINE_ERROR_MSG(WE_LOG_PBE, "Salt type not OCTET_STRING");
+        ret = 0;
+    }
+    /* Get key length if present and check against cipher's. */
+    if ((ret == 1) && (kdf->keylength != NULL)) {
+        kdfKeyLen = (int)ASN1_INTEGER_get(kdf->keylength);
+        if (kdfKeyLen != kLen) {
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PBE, "ASN1_INTEGER_get", kdfKeyLen);
+            ret = 0;
+        }
+    }
+    /* Get the PRF if present - default is HMAC-SHA1. */
+    if ((ret == 1) && (kdf->prf != NULL)) {
+        prfNid = OBJ_obj2nid(kdf->prf->algorithm);
+    }
+    if (ret == 1) {
+        /* Get the wolfCrypt hash type. */
+        hashType = we_hmac_to_wc_hash(prfNid);
+        if (hashType == 0) {
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PBE, "we_hmac_to_wc_hash", hashType);
+            ret = 0;
+        }
+    }
+    if (ret == 1) {
+        /* Get salt and iterations. */
+        salt = kdf->salt->value.octet_string->data;
+        sLen = kdf->salt->value.octet_string->length;
+        iterations = (int)ASN1_INTEGER_get(kdf->iter);
+
+        WOLFENGINE_MSG(WE_LOG_PBE, "Deriving key with PBKDF2");
+        /* Derive the key. */
+        rc = wc_PBKDF2_ex(key, (const byte*)passwd, passwdLen, salt, sLen,
+            iterations, kLen, hashType, NULL, INVALID_DEVID);
+        if (rc != 0) {
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PBE, "wc_PBKDF2_ex", rc);
+            ret = 0;
+        }
+    }
+    if (ret == 1) {
+        /* Set up cipher with key and encrypt or decrypt. */
+        ret = EVP_CipherInit_ex(ctx, NULL, NULL, key, NULL, en_de);
+    }
+
+    /* Free allocated data. */
+    PBKDF2PARAM_free(kdf);
+
+    WOLFENGINE_LEAVE(WE_LOG_PBE, "we_pbkdf2_keygen", ret);
+
+    return ret;
+}
+
+/**
+ * Convert the OpenSSL digest NID into a wolfCrypt hash type.
+ *
+ * OpenSSL supportes PBE with: MD2, MD5 and SHA-1.
+ * Only supporting SHA-1.
+ * (NID_pbe_WithSHA1And3_Key_TripleDES_CBC)
+ *
+ * @param  nid  [in]  OpenSSL digest NID.
+ * @returns  wolfCrypt hash type on success and 0 on failure.
+ */
+static int we_digest_to_wc_hash(int nid)
+{
+    int hashType;
+
+    switch (nid) {
+    #ifndef NO_SHA
+        case NID_sha1:
+            hashType = WC_SHA;
+            break;
+    #endif
+        default:
+            /* Unsupported hash algorithm in wolfCrypt. */
+            WOLFENGINE_ERROR_MSG(WE_LOG_PBE, "Hash not supported");
+            hashType = 0;
+            break;
+    }
+
+    return hashType;
+}
+
+/**
+ * Determine key and IV length for the OpenSSL cipher NID.
+ *
+ * OpenSSL supportes with PBE:
+ *    RC2-CBC (40-bits and 128-bits)
+ *    RC4
+ *    DES-CBC
+ *    DES-EDE-CBC (2 keys)
+ *    DES-EDE3-CBC (3 keys)
+ * Only supporting DES-EDE3-CBC.
+ * (NID_pbe_WithSHA1And3_Key_TripleDES_CBC)
+ *
+ * @param  nid     [in]   OpenSSL digest NID.
+ * @param  keyLen  [out]  Length of key for cipher.
+ * @param  ivLen   [out]  Length of IV for cipher.
+ * @returns  1 on success and 0 on failure.
+ */
+static int we_cipher_to_lengths(int nid, int *keyLen, int *ivLen)
+{
+    int ret = 1;
+
+    switch (nid) {
+    #ifndef NO_DES3
+        /* 3-key DES CBC. */
+        case NID_des_ede3_cbc:
+            *keyLen = 24;
+            *ivLen = 8;
+            break;
+    #endif
+        default:
+            /* Unsupported cipher algorithm in wolfCrypt. */
+            WOLFENGINE_ERROR_MSG(WE_LOG_PBE, "Cipher not supported");
+            ret = 0;
+            break;
+    }
+
+    return ret;
+}
+
+/**
+ * Derive the key with PBE and BER encoded parameters using the password.
+ *
+ * OpenSSL 1.1.0+ convert password from UTF8 to Unicode.
+ * OpenSSL 1.0.2 converts password from ASCII to Unicode.
+ *
+ * @param  ctx        [in]  Cipher context to set up with a key.
+ * @param  passwd     [in]  Password to derive key from.
+ * @param  passwdLen  [in]  Length of password.
+ * @param  param      [in]  BER encoded PBKDF2 parameters
+ * @param  cipher     [in]  Cipher to use for encryption.
+ * @param  md         [in]  Hash algorithm to use in derivation.
+ * @param  en_de      [in]  Setup cipher for encryption or decryption.
+ * @returns  1 on success and 0 on failure.
+ */
+static int we_pbe_keyivgen(EVP_CIPHER_CTX *ctx, const char *passwd,
+    int passwdLen, ASN1_TYPE *param, const EVP_CIPHER *cipher, const EVP_MD *md,
+    int en_de)
+{
+    int ret = 1;
+    int rc;
+    PBEPARAM *params = NULL;
+    int iterations = 1;
+    int kLen;
+    int ivLen;
+    unsigned char *salt;
+    int sLen;
+    int hashType;
+    unsigned char key[EVP_MAX_KEY_LENGTH];
+    unsigned char iv[EVP_MAX_IV_LENGTH];
+    unsigned char *uniPass = NULL;
+    int uniLen;
+
+    WOLFENGINE_ENTER(WE_LOG_PBE, "we_pbe_keyivgen");
+    WOLFENGINE_MSG_VERBOSE(WE_LOG_PBE, "ARGS [ctx = %p, passwd = %p, "
+        "passwdLen = %d, param = %p, cipher = %p, md = %p, en_de = %d]", ctx,
+        passwd, passwdLen, param, cipher, md, en_de);
+
+    /* Validate parameters. */
+    if (cipher == NULL) {
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PBE, "we_pbe_keygen", cipher);
+        ret = 0;
+    }
+
+    if (ret == 1) {
+        /* Decode the PBE parameters. */
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+        params = ASN1_TYPE_unpack_sequence(ASN1_ITEM_rptr(PBEPARAM), param);
+#else
+        const unsigned char *pBuf = param->value.sequence->data;
+        int pLen = param->value.sequence->length;
+        params = d2i_PBEPARAM(NULL, &pBuf, pLen);
+#endif /* OPENSSL_VERSION_NUMBER >= 0x10100000L */
+        if (params == NULL) {
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PBE, "ASN1_TYPE_unpack_sequence",
+                                       params);
+            ret = 0;
+        }
+    }
+    if ((ret == 1) && (params->iter != NULL)) {
+        /* Get the iteration count from parameters. */
+        iterations = (int)ASN1_INTEGER_get(params->iter);
+    }
+
+    if (ret == 1) {
+        /* Determine hash to use from parameter. */
+        hashType = we_digest_to_wc_hash(EVP_MD_nid(md));
+        if (hashType == 0) {
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PBE, "we_digest_to_wc_hash", hashType);
+            ret = 0;
+        }
+    }
+    if (ret == 1) {
+        /* Determine key and IV length to derive from parameter. */
+        ret = we_cipher_to_lengths(EVP_CIPHER_nid(cipher), &kLen, &ivLen);
+        if (ret != 1) {
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PBE, "we_cipher_to_lengths", ret);
+        }
+    }
+    if (ret == 1) {
+        /* Convert password to unicode. Behaviour matches version of OpenSSL. */
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+        if (OPENSSL_utf82uni(passwd, passwdLen, &uniPass, &uniLen) == NULL) {
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PBE, "OPENSSL_utf82uni", NULL);
+            ret = 0;
+        }
+#else
+        if (OPENSSL_asc2uni(passwd, passwdLen, &uniPass, &uniLen) == NULL) {
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PBE, "OPENSSL_utf82uni", NULL);
+            ret = 0;
+        }
+#endif
+    }
+    if (ret == 1) {
+        /* Get the salt from the parameters. */
+        salt = params->salt->data;
+        sLen = params->salt->length;
+
+        WOLFENGINE_MSG(WE_LOG_PBE, "Deriving key with PKCS#12 PBKDF");
+        /* Derive the key using the unicode password and id for a key. */
+        rc = wc_PKCS12_PBKDF_ex(key, uniPass, uniLen, salt, sLen, iterations,
+            kLen, hashType, PKCS12_KEY_ID, NULL);
+        if (rc != 0) {
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PBE, "wc_PBKDF1_ex", rc);
+            ret = 0;
+        }
+    }
+    if (ret == 1) {
+        /* Derive the IV using the unicode password and id for an IV. */
+        rc = wc_PKCS12_PBKDF_ex(iv, uniPass, uniLen, salt, sLen, iterations,
+            ivLen, hashType, PKCS12_IV_ID, NULL);
+        if (rc != 0) {
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PBE, "wc_PBKDF1_ex", rc);
+            ret = 0;
+        }
+    }
+    if (ret == 1) {
+        /* Setup the cipher context with the cipher, key, iv and enc/dec. */
+        ret = EVP_CipherInit_ex(ctx, cipher, NULL, key, iv, en_de);
+    }
+
+    /* Dispose of allocated data. */
+    if (uniPass != NULL) {
+        OPENSSL_clear_free(uniPass, uniLen);
+    }
+    PBEPARAM_free(params);
+
+    WOLFENGINE_LEAVE(WE_LOG_PBE, "we_pbe_keyivgen", ret);
+
+    return ret;
+}
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+/**
+ * Derive the key with PBES2 and BER encoded parameters using the password.
+ *
+ * @param  ctx        [in]  Cipher context to set up with a key.
+ * @param  passwd     [in]  Password to derive key from.
+ * @param  passwdLen  [in]  Length of password.
+ * @param  param      [in]  BER encoded PBKDF2 parameters
+ * @param  cipher     [in]  Cipher to use for encryption. (ignored)
+ * @param  md         [in]  Hash algorithm to use in derivation. (ignored)
+ * @param  en_de      [in]  Setup cipher for encryption or decryption.
+ * @returns  1 on success and 0 on failure.
+ */
+static int we_pbes2_keyivgen(EVP_CIPHER_CTX *ctx, const char *passwd,
+    int passwdLen, ASN1_TYPE *param, const EVP_CIPHER *c, const EVP_MD *md,
+    int en_de)
+{
+    int ret = 1;
+    int rc;
+    PBE2PARAM *pbe2 = NULL;
+    const EVP_CIPHER *cipher;
+
+    /* Cipher ingored in favour of PBES2 parameters. */
+    (void)c;
+
+    WOLFENGINE_ENTER(WE_LOG_PBE, "we_pbes2_keyivgen");
+    WOLFENGINE_MSG_VERBOSE(WE_LOG_PBE, "ARGS [ctx = %p, passwd = %p, "
+        "passwdLen = %d, param = %p, c = %p, md = %p, en_de = %d]", ctx, passwd,
+        passwdLen, param, c, md, en_de);
+
+    /* Check param is not NULL. */
+    if (param == NULL) {
+        WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PBE, "we_pbes2_keyivgen", param);
+        ret = 0;
+    }
+    /* Ensure param is a SEQUENCE. */
+    if ((ret == 1) && (param->type != V_ASN1_SEQUENCE)) {
+        WOLFENGINE_ERROR_MSG(WE_LOG_PBE, "Parameters not SEQUENCE");
+        ret = 0;
+    }
+    /* Ensure param has data. */
+    if ((ret == 1) && (param->value.sequence == NULL)) {
+        WOLFENGINE_ERROR_MSG(WE_LOG_PBE, "param->value.sequence == NULL");
+        ret = 0;
+    }
+    if (ret == 1) {
+        const unsigned char *pBuf = param->value.sequence->data;
+        int pLen = param->value.sequence->length;
+
+        /* Decode the PBES2 parameters. */
+        pbe2 = d2i_PBE2PARAM(NULL, &pBuf, pLen);
+        if (pbe2 == NULL) {
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PBE, "d2i_PBE2PARAM", pbe2);
+            ret = 0;
+        }
+    }
+
+    /* KDF algorithm must be PBKDF2. */
+    if ((ret == 1) &&
+        (OBJ_obj2nid(pbe2->keyfunc->algorithm) != NID_id_pbkdf2)) {
+        WOLFENGINE_ERROR_MSG(WE_LOG_PBE, "KDF algorithm not PBKDF2");
+        ret = 0;
+    }
+
+    if (ret == 1) {
+        /* Convert encryption algorithm into a cipher object. */
+        cipher = EVP_get_cipherbyobj(pbe2->encryption->algorithm);
+        if (cipher == NULL) {
+            WOLFENGINE_ERROR_FUNC_NULL(WE_LOG_PBE, "EVP_get_cipherbyobj", NULL);
+            ret = 0;
+        }
+    }
+
+    if (ret == 1) {
+       WOLFENGINE_MSG(WE_LOG_PBE, "Setting up PBES2 key");
+        /* Create cipher context with cipher and enc/dec. */
+        ret = EVP_CipherInit_ex(ctx, cipher, NULL, NULL, NULL, en_de);
+        if (ret != 1) {
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PBE, "EVP_CipherInit_ex", ret);
+        }
+    }
+    if (ret == 1) {
+        /* Set the BER encoded encryption parameters. */
+        rc = EVP_CIPHER_asn1_to_param(ctx, pbe2->encryption->parameter);
+        if (rc < 0) {
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PBE, "EVP_CIPHER_asn1_to_param", rc);
+        }
+    }
+    if (ret == 1) {
+        /* Derive the key using PBKDF2. */
+        ret = we_pbkdf2_keygen(ctx, passwd, passwdLen, pbe2->keyfunc->parameter,
+                               cipher, md, en_de);
+    }
+
+    /* Dispose of allocated data. */
+    PBE2PARAM_free(pbe2);
+
+    WOLFENGINE_LEAVE(WE_LOG_PBE, "we_pbes2_keyivgen", ret);
+
+    return ret;
+}
+#endif /* OPENSSL_VERSION_NUMBER < 0x10100000L */
+#endif /* !NO_PWDBASED */
+
+/**
+ * Set the PBE functions to lookup for PBE, PBES2 and PKBDF2.
+ *
+ * @returns  1 on success and 0 on failure.
+ */
+int we_init_pbe_keygen()
+{
+#ifndef NO_PWDBASED
+    int ret;
+
+    ret = EVP_PBE_alg_add_type(EVP_PBE_TYPE_OUTER, NID_id_pbkdf2, -1, -1,
+        we_pbkdf2_keygen);
+    if (ret != 1) {
+        WOLFENGINE_ERROR_FUNC(WE_LOG_PBE, "EVP_PBE_alg_add_type", ret);
+    }
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+    if (ret == 1) {
+        /* Let PKCS5_v2_PBE_keyivgen look up the KDF function. */
+        ret = EVP_PBE_alg_add_type(EVP_PBE_TYPE_KDF, NID_id_pbkdf2, -1, -1,
+            we_pbkdf2_keygen);
+        if (ret != 1) {
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PBE, "EVP_PBE_alg_add_type", ret);
+        }
+    }
+#else
+    if (ret == 1) {
+        /* PKCS5_v2_PBE_keyivgen doesn't look up the KDF function. */
+        ret = EVP_PBE_alg_add_type(EVP_PBE_TYPE_OUTER, NID_pbes2, -1, -1,
+            we_pbes2_keyivgen);
+        if (ret != 1) {
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PBE, "EVP_PBE_alg_add_type", ret);
+        }
+    }
+#endif /* OPENSSL_VERSION_NUMBER >= 0x10100000L */
+    if (ret == 1) {
+        ret = EVP_PBE_alg_add_type(EVP_PBE_TYPE_OUTER,
+            NID_pbe_WithSHA1And3_Key_TripleDES_CBC, NID_des_ede3_cbc, NID_sha1,
+            we_pbe_keyivgen);
+        if (ret != 1) {
+            WOLFENGINE_ERROR_FUNC(WE_LOG_PBE, "EVP_PBE_alg_add_type", ret);
+        }
+    }
+
+    return ret;
+#else
+    WOLFENGINE_MSG(WE_LOG_PBE, "wolfCrypt does not support PBKDF");
+    return 1;
+#endif /* !NO_PWDBASED */
+}
+
+#endif /* WE_HAVE_PBE */

--- a/test-openssl-version.sh
+++ b/test-openssl-version.sh
@@ -95,7 +95,8 @@ do_config() {
 
     echo -n "  Configure ... "
     # Using development version of OpenSSL not install - set LDFLAGS
-    ./configure LDFLAGS="-L$OPENSSL_DIR" $EXTRA_OPTS \
+    ./configure LDFLAGS="-L$OPENSSL_DIR $WOLFENGINE_EXTRA_LDFLAGS" $EXTRA_OPTS \
+            CPPFLAGS="$WOLFENGINE_EXTRA_CPPFLAGS" \
             --with-openssl=$OPENSSL_DIR >$TMP_FILE 2>&1
     if [ $? != 0 ]; then
         cat $TMP_FILE
@@ -171,11 +172,8 @@ do
             echo "Disabling hash in wolfengine"
             EXTRA_OPTS="$EXTRA_OPTS --disable-hash"
             ;;
-        --gcm)
-            EXTRA_OPTS="$EXTRA_OPTS --enable-aesgcm"
-            ;;
-        --ccm)
-            EXTRA_OPTS="$EXTRA_OPTS --enable-aesccm"
+        --pbe)
+            EXTRA_OPTS="$EXTRA_OPTS --enable-pbe"
             ;;
         --clang)
             EXTRA_OPTS="$EXTRA_OPTS CC=clang"

--- a/test/include.am
+++ b/test/include.am
@@ -19,6 +19,7 @@ test_unit_test_SOURCES = \
 	test/test_hkdf.c \
 	test/test_hmac.c \
 	test/test_logging.c \
+	test/test_pbe.c \
 	test/test_pkey.c \
 	test/test_rand.c \
 	test/test_rsa.c \

--- a/test/test_pbe.c
+++ b/test/test_pbe.c
@@ -1,0 +1,364 @@
+/* test_pbe.c
+ *
+ * Copyright (C) 2019-2021 wolfSSL Inc.
+ *
+ * This file is part of wolfengine.
+ *
+ * wolfengine is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfengine is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#include "unit.h"
+
+#ifdef WE_HAVE_PBE
+
+static const unsigned char pbeData[] = {
+    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+};
+static const unsigned char pbeEncSha1Des3[] = {
+    0x30, 0xe7, 0x72, 0x5d, 0xf8, 0xb3, 0x56, 0x58,
+    0xbb, 0xa6, 0x1b, 0x58, 0x16, 0x36, 0x09, 0xab,
+    0x7a, 0x23, 0x22, 0x4c, 0x23, 0x5a, 0x16, 0x10
+};
+static const unsigned char pbeEncAes128Cbc[] = {
+    0x86, 0xc4, 0xa8, 0x5f, 0x76, 0x62, 0xfa, 0xf7,
+    0x5a, 0x54, 0xbc, 0xbf, 0x03, 0xa6, 0x9b, 0x48,
+    0x72, 0x00, 0x1d, 0xd9, 0x1d, 0xca, 0xab, 0xd7,
+    0xb2, 0xea, 0x47, 0x9a, 0x7e, 0x95, 0x25, 0x64
+};
+static const unsigned char pbeEncAes256Cbc[] = {
+    0xc4, 0x7b, 0x8b, 0x32, 0x05, 0x60, 0xbb, 0xef,
+    0x6e, 0xf0, 0x98, 0x39, 0x96, 0x6e, 0xf8, 0x6e,
+    0xb2, 0x37, 0xa4, 0x3c, 0xd6, 0x82, 0x21, 0x4c,
+    0x25, 0x13, 0xd4, 0xd7, 0x92, 0xac, 0x90, 0xf1
+};
+
+/* Format of parameters:
+ *    SEQ
+ *      OCT <salt>
+ *      INT <iterations=10000>
+ */
+static const unsigned char pbeParamPbe[] = {
+    0x30, 0x0e,
+          0x04, 0x08,
+                0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+          0x02, 0x02, 0x27, 0x10
+};
+
+
+/* Format of parameters:
+ *  SEQ {pbes2}
+ *    SEQ {kdf}
+ *      OBJ <pbkdf2>
+ *      SEQ
+ *        OCT <salt>
+ *        INT <iterations=10000>
+ *        [INT <keylength>]
+ *        [SEQ {prf}
+ *           OBJ <hmac=HMAC-SHA256>
+ *         ]
+ *    SEQ {enc_alg}
+ *      OBJ <aes128-cbc>
+ */
+static const unsigned char pbeParamPbes2Aes128Cbc[] = {
+    0x30, 0x39,
+          0x30, 0x2a,
+                0x06, 0x09,
+                      0x2A,0x86,0x48,0x86,0xF7,0x0D,0x01,0x05,0x0C,
+                0x30, 0x1d,
+                      0x04, 0x08,
+                            0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+                      0x02, 0x02, 0x27, 0x10,
+                      0x02, 0x01, 0x10,
+                      0x30, 0x0a,
+                            0x06, 0x08,
+                                  0x2A,0x86,0x48,0x86,0xF7,0x0D,0x02,0x09,
+          0x30, 0x0b,
+                0x06, 0x09,
+                      0x60,0x86,0x48,0x01,0x65,0x03,0x04,0x01,0x02,
+};
+
+/* Format of parameters:
+ *  SEQ {pbes2}
+ *    SEQ {kdf}
+ *      OBJ <pbkdf2>
+ *      SEQ
+ *        OCT <salt>
+ *        INT <iterations=10000>
+ *        [INT <keylength> not included]
+ *        [SEQ {prf}
+ *           OBJ <hmac=HMAC-SHA384>
+ *         ]
+ *    SEQ {enc_alg}
+ *      OBJ <aes256-cbc>
+ */
+static const unsigned char pbeParamPbes2Aes256Cbc[] = {
+    0x30, 0x36,
+          0x30, 0x27,
+                0x06, 0x09,
+                      0x2A,0x86,0x48,0x86,0xF7,0x0D,0x01,0x05,0x0C,
+                0x30, 0x1a,
+                      0x04, 0x08,
+                            0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+                      0x02, 0x02, 0x27, 0x10,
+                      0x30, 0x0a,
+                            0x06, 0x08,
+                                  0x2A,0x86,0x48,0x86,0xF7,0x0D,0x02,0x0A,
+          0x30, 0x0b,
+                0x06, 0x09,
+                      0x60,0x86,0x48,0x01,0x65,0x03,0x04,0x01,0x2A,
+};
+
+static int test_pbe_encipher(ASN1_OBJECT *obj, ASN1_TYPE *param,
+    const unsigned char *in, size_t inLen, unsigned char *out, int *outLen,
+    int enc_dec)
+{
+    int err = 0;
+    int rc;
+    EVP_CIPHER_CTX *ctx;
+    int len;
+
+    ctx = EVP_CIPHER_CTX_new();
+    if (ctx == NULL) {
+        PRINT_MSG("Failed to create EVP_CIPHER_CTX");
+        err = 1;
+    }
+    if (!err) {
+        rc = EVP_PBE_CipherInit(obj, "password", 8, param, ctx, enc_dec);
+        if (rc != 1) {
+            PRINT_MSG("Failed to initialize PBE cipher");
+            err = 1;
+        }
+    }
+    if (!err) {
+        rc = EVP_CipherUpdate(ctx, out, &len, in, (int)inLen);
+        if (rc != 1) {
+            PRINT_MSG("Failed to update PBE cipher");
+            err = 1;
+        }
+    }
+    if (!err) {
+        *outLen = len;
+        rc = EVP_CipherFinal_ex(ctx, out + len, &len);
+        if (rc != 1) {
+            PRINT_MSG("Failed to finalize PBE cipher");
+            err = 1;
+        }
+    }
+    if (!err) {
+        *outLen += len;
+    }
+
+    EVP_CIPHER_CTX_free(ctx);
+    return err;
+}
+
+static int test_pbe_op(int nid, const unsigned char* params, int paramsLen,
+    const unsigned char *in, size_t inLen, unsigned char *out, int *outLen,
+    int enc_dec)
+{
+    int err = 0;
+    int rc;
+    ASN1_OBJECT *obj = OBJ_nid2obj(nid);
+    ASN1_TYPE *param = NULL;
+    ASN1_STRING *string = NULL;
+
+    param = ASN1_TYPE_new();
+    if (param == NULL) {
+        PRINT_MSG("Failed to create ASN1_TYPE");
+        err = 1;
+    }
+    if (!err) {
+        string = ASN1_STRING_type_new(V_ASN1_SEQUENCE);
+        if (string == NULL) {
+            PRINT_MSG("Failed to create ASN1_STRING");
+            err = 1;
+        }
+    }
+    if (!err) {
+        rc = ASN1_STRING_set(string, params, paramsLen);
+        if (rc != 1) {
+            PRINT_MSG("Failed to set parameters into ASN1_STRING");
+            err = 1;
+        }
+    }
+    if (!err) {
+        ASN1_TYPE_set(param, V_ASN1_SEQUENCE, string);
+        string = NULL;
+
+        err = test_pbe_encipher(obj, param, in, inLen, out, outLen, enc_dec);
+    }
+
+    ASN1_STRING_free(string);
+    ASN1_TYPE_free(param);
+
+    return err;
+}
+
+static int test_pbe_sha1_des3_pbkdf1_op(const unsigned char *in, size_t inLen,
+    unsigned char *out, int *outLen, int enc_dec)
+{
+    return test_pbe_op(NID_pbe_WithSHA1And3_Key_TripleDES_CBC, pbeParamPbe,
+        sizeof(pbeParamPbe), in, inLen, out, outLen, enc_dec);
+}
+
+static int test_pbe_sha1_des3_pbkdf1()
+{
+    int err;
+    unsigned char pbeEnc[sizeof(pbeData) + 8];
+    unsigned char pbeDec[sizeof(pbeData) + 8];
+    int encLen;
+    int decLen;
+
+    PRINT_MSG("Encrypt");
+    err = test_pbe_sha1_des3_pbkdf1_op(pbeData, sizeof(pbeData), pbeEnc,
+        &encLen, 1);
+    if (!err) {
+        if ((encLen != (int)sizeof(pbeEncSha1Des3)) ||
+            memcmp(pbeEncSha1Des3, pbeEnc, encLen) != 0) {
+            PRINT_MSG("Different encrypted data");
+            PRINT_BUFFER("PBE encrypted", pbeEnc, encLen);
+            err = 1;
+        }
+    }
+    if (!err) {
+        PRINT_MSG("Decrypt");
+        err = test_pbe_sha1_des3_pbkdf1_op(pbeEnc, encLen, pbeDec,
+            &decLen, 0);
+    }
+    if (!err) {
+        if ((decLen != (int)sizeof(pbeData)) ||
+            memcmp(pbeData, pbeDec, decLen) != 0) {
+            PRINT_MSG("Different decrypted data");
+            PRINT_BUFFER("PBE decrypted", pbeDec, decLen);
+            err = 1;
+        }
+    }
+
+    return err;
+}
+
+static int test_pbe_pbes2_aes128_cbc_op(const unsigned char *in, size_t inLen,
+    unsigned char *out, int *outLen, int enc_dec)
+{
+    return test_pbe_op(NID_pbes2, pbeParamPbes2Aes128Cbc,
+        sizeof(pbeParamPbes2Aes128Cbc), in, inLen, out, outLen, enc_dec);
+}
+
+static int test_pbe_pbes2_aes128_cbc()
+{
+    int err;
+    unsigned char pbeEnc[sizeof(pbeData) + 16];
+    unsigned char pbeDec[sizeof(pbeData) + 16];
+    int encLen;
+    int decLen;
+
+    PRINT_MSG("Encrypt");
+    err = test_pbe_pbes2_aes128_cbc_op(pbeData, sizeof(pbeData), pbeEnc,
+        &encLen, 1);
+    if (!err) {
+        if ((encLen != (int)sizeof(pbeEncAes128Cbc)) ||
+            memcmp(pbeEncAes128Cbc, pbeEnc, encLen) != 0) {
+            PRINT_MSG("Different encrypted data");
+            PRINT_BUFFER("PBE encrypted", pbeEnc, encLen);
+            err = 1;
+        }
+    }
+    if (!err) {
+        PRINT_MSG("Decrypt");
+        err = test_pbe_pbes2_aes128_cbc_op(pbeEnc, encLen, pbeDec,
+            &decLen, 0);
+    }
+    if (!err) {
+        if ((decLen != (int)sizeof(pbeData)) ||
+            memcmp(pbeData, pbeDec, decLen) != 0) {
+            PRINT_MSG("Different decrypted data");
+            PRINT_BUFFER("PBE decrypted", pbeDec, decLen);
+            err = 1;
+        }
+    }
+
+    return err;
+}
+
+static int test_pbe_pbes2_aes256_cbc_op(const unsigned char *in, size_t inLen,
+    unsigned char *out, int *outLen, int enc_dec)
+{
+    return test_pbe_op(NID_pbes2, pbeParamPbes2Aes256Cbc,
+        sizeof(pbeParamPbes2Aes256Cbc), in, inLen, out, outLen, enc_dec);
+}
+
+static int test_pbe_pbes2_aes256_cbc()
+{
+    int err;
+    unsigned char pbeEnc[sizeof(pbeData) + 16];
+    unsigned char pbeDec[sizeof(pbeData) + 16];
+    int encLen;
+    int decLen;
+
+    PRINT_MSG("Encrypt");
+    err = test_pbe_pbes2_aes256_cbc_op(pbeData, sizeof(pbeData), pbeEnc,
+        &encLen, 1);
+    if (!err) {
+        if ((encLen != (int)sizeof(pbeEncAes256Cbc)) ||
+            memcmp(pbeEncAes256Cbc, pbeEnc, encLen) != 0) {
+            PRINT_MSG("Different encrypted data");
+            PRINT_BUFFER("PBE encrypted", pbeEnc, encLen);
+            err = 1;
+        }
+    }
+    if (!err) {
+        PRINT_MSG("Decrypt");
+        err = test_pbe_pbes2_aes256_cbc_op(pbeEnc, encLen, pbeDec,
+            &decLen, 0);
+    }
+    if (!err) {
+        if ((decLen != (int)sizeof(pbeData)) ||
+            memcmp(pbeData, pbeDec, decLen) != 0) {
+            PRINT_MSG("Different decrypted data");
+            PRINT_BUFFER("PBE decrypted", pbeDec, decLen);
+            err = 1;
+        }
+    }
+
+    return err;
+}
+
+int test_pbe(ENGINE *e, void *data)
+{
+    int err;
+
+    (void)e;
+    (void)data;
+
+#ifdef NO_PWDBASED
+    PRINT_MSG("Not using wolfEngine - PBKDF not available in wolfCrypt");
+#endif
+
+    PRINT_MSG("PBE DES-EDE3-CBC SHA-1");
+    err = test_pbe_sha1_des3_pbkdf1();
+    if (err == 0) {
+        PRINT_MSG("PBES2 AES128-CBC HMAC-SHA-256");
+        err = test_pbe_pbes2_aes128_cbc();
+    }
+    if (err == 0) {
+        PRINT_MSG("PBES2 AES256-CBC HMAC-SHA-384");
+        err = test_pbe_pbes2_aes256_cbc();
+    }
+
+    return err;
+}
+
+#endif

--- a/test/unit.c
+++ b/test/unit.c
@@ -333,9 +333,13 @@ TEST_CASE test_case[] = {
 
 #ifdef WE_HAVE_ECDSA
 #if OPENSSL_VERSION_NUMBER <= 0x100020ffL
-    TEST_DECL(test_ecdsa, NULL)
+    TEST_DECL(test_ecdsa, NULL),
 #endif
 #endif /* WE_HAVE_ECDSA */
+
+#ifdef WE_HAVE_PBE
+    TEST_DECL(test_pbe, NULL),
+#endif
 };
 #define TEST_CASE_CNT   (int)(sizeof(test_case) / sizeof(*test_case))
 
@@ -698,6 +702,10 @@ int main(int argc, char* argv[])
             err = 1;
         }
     }
+
+#if defined(WE_HAVE_PBE) && (OPENSSL_VERSION_NUMBER < 0x10100000L)
+    OpenSSL_add_all_algorithms();
+#endif
 
     if (err == 0 && runTests) {
         err = run_tests(e, runAll);

--- a/test/unit.h
+++ b/test/unit.h
@@ -475,4 +475,8 @@ int test_ecdsa(ENGINE *e, void *data);
 
 #endif /* WE_HAVE_ECC */
 
+#ifdef WE_HAVE_PBE
+int test_pbe(ENGINE *e, void *data);
+#endif /* WE_HAVE_PBE */
+
 #endif /* UNIT_H */


### PR DESCRIPTION
Algorithms not exported in FIPS library.
Disabled by default.