### PR TITLE
register ECC methods for ECDSA_do_sign/ECDSA_do_verify

### DIFF
--- a/include/wolfengine/we_openssl_bc.h
+++ b/include/wolfengine/we_openssl_bc.h
@@ -34,6 +34,7 @@
 #include <openssl/evp.h>
 #include <openssl/crypto.h>
 #include <openssl/ec.h>
+#include <openssl/ecdsa.h>
 #include <openssl/dh.h>
 #include <openssl/rsa.h>
 
@@ -156,6 +157,7 @@ void DH_get0_pqg(DH *dh, const BIGNUM **p, const BIGNUM **q, const BIGNUM **g);
 int DH_set0_pqg(DH *dh, BIGNUM *p, BIGNUM *q, BIGNUM *g);
 int DH_set0_key(DH *dh, BIGNUM *pub_key, BIGNUM *priv_key);
 DH *EVP_PKEY_get0_DH(EVP_PKEY *pkey);
+int ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s);
 
 size_t EC_POINT_point2buf(const EC_GROUP *group, const EC_POINT *point,
                                  point_conversion_form_t form,

--- a/src/we_openssl_bc.c
+++ b/src/we_openssl_bc.c
@@ -622,6 +622,22 @@ int DH_set0_key(DH *dh, BIGNUM *pub_key, BIGNUM *priv_key)
     return 1;
 }
 
+int ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s)
+{
+    if (r == NULL || s == NULL) {
+        return 0;
+    }
+
+    /* clear BIGNUM structs first */
+    BN_clear_free(sig->r);
+    BN_clear_free(sig->s);
+
+    sig->r = r;
+    sig->s = s;
+
+    return 1;
+}
+
 #endif /* OPENSSL_VERSION_NUMBER < 0x10100000L */
 
 #if OPENSSL_VERSION_NUMBER < 0x10101000L


### PR DESCRIPTION
This diff on this PR for we_ecc.c is hard to decipher, but changes in this PR include:

- Register we_ecdsa_sign_setup() and we_ecdsa_do_sign_ex() with EC_KEY_METHOD_set_sign()
- Register we_ecdsa_do_verify() with EC_KEY_METHOD_set_verify()

For the above, we_ecdsa_do_sign_ex() and we_ecdsa_do_verify() were moved up in location in we_ecc.c, thus most of the diff changes in we_ecc.c.

- Simplified we_ecdsa_do_verify() to use a DER signature instead of r,s components internally
- Adds tests for ECDSA_do_sign() and ECDSA_do_verify()

This fixed a failing unit test in the openssh tests that used ECDSA_do_sign/verify.