### PR TITLE
Add flag EVP_CIPH_ALWAYS_CALL_INIT to AES-CBC implementation.

### DIFF
--- a/src/we_aes_block.c
+++ b/src/we_aes_block.c
@@ -297,7 +297,8 @@ static int we_aes_cbc_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
  */
 #define AES_CBC_FLAGS              \
     (EVP_CIPH_FLAG_DEFAULT_ASN1  | \
-     EVP_CIPH_CBC_MODE)
+     EVP_CIPH_CBC_MODE           | \
+     EVP_CIPH_ALWAYS_CALL_INIT)
 
 /** AES128-CBC EVP cipher method. */
 EVP_CIPHER* we_aes128_cbc_ciph = NULL;


### PR DESCRIPTION
This resolves ZD 12683.