### PR TITLE
Allow we_aes_cbc_init to be called with NULL IV and key.

### DIFF
--- a/src/we_aes_block.c
+++ b/src/we_aes_block.c
@@ -71,11 +71,6 @@ static int we_aes_cbc_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
     WOLFENGINE_MSG_VERBOSE(WE_LOG_CIPHER, "ARGS [ctx = %p, key = %p, "
                            "iv = %p, enc = %d]", ctx, key, iv, enc);
 
-    if ((iv == NULL) && (key == NULL)) {
-        WOLFENGINE_ERROR_MSG(WE_LOG_CIPHER, "iv == NULL && key == NULL");
-        ret = 0;
-    }
-
     if (ret == 1) {
         aes = (we_AesBlock *)EVP_CIPHER_CTX_get_cipher_data(ctx);
         if (aes == NULL) {
@@ -289,12 +284,7 @@ static int we_aes_cbc_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
     return ret;
 }
 
-/** Flags for AES-CBC method.
- *
- * NOTE: EVP_CIPH_ALWAYS_CALL_INIT is deliberately not added. This flag
- *       causes the AES init method to be called even if key is NULL. Currently
- *       wolfEngine does not need to initialize until a key is available.
- */
+/* Flags for AES-CBC method. */
 #define AES_CBC_FLAGS              \
     (EVP_CIPH_FLAG_DEFAULT_ASN1  | \
      EVP_CIPH_CBC_MODE           | \


### PR DESCRIPTION
Previously, if the IV and key were both NULL, we treated it as an error.
However, now that we're using `EVP_CIPH_ALWAYS_CALL_INIT`, this function can
potentially be called with both parameters NULL. OpenSSL handles this case fine,
so wolfEngine should, too. It's a no-op.

See ZD 12683.