### PR TITLE
Fix bug with AES-CTR initialization.

### DIFF
--- a/test/unit.c
+++ b/test/unit.c
@@ -116,6 +116,7 @@ TEST_CASE test_case[] = {
     TEST_DECL(test_aes128_ctr_stream, NULL),
     TEST_DECL(test_aes192_ctr_stream, NULL),
     TEST_DECL(test_aes256_ctr_stream, NULL),
+    TEST_DECL(test_aes_ctr_iv_init_regression, NULL),
 #endif
 #ifdef WE_HAVE_AESGCM
     TEST_DECL(test_aes128_gcm, NULL),

--- a/test/unit.h
+++ b/test/unit.h
@@ -154,6 +154,8 @@ int test_aes128_ctr_stream(ENGINE *e, void *data);
 int test_aes192_ctr_stream(ENGINE *e, void *data);
 int test_aes256_ctr_stream(ENGINE *e, void *data);
 
+int test_aes_ctr_iv_init_regression(ENGINE *, void *);
+
 #endif
 
 #ifdef WE_HAVE_AESGCM


### PR DESCRIPTION
OpenSSL allows the user to call EVP_CipherInit with NULL key or IV. Prior to
this commit, setting the IV first (with key NULL) and then setting the key (with
IV NULL) would result in the IV getting set to 0s on the call to set the key.
This was discovered in testing with OpenSSH. This commit fixes this bug and adds
a regression test for it.