### PR TITLE
Don't attempt to compile DES3-CBC code if wolfSSL defines `NO_DES3`.

### DIFF
--- a/include/wolfengine/we_internal.h
+++ b/include/wolfengine/we_internal.h
@@ -85,6 +85,11 @@
     #include <wolfssl/wolfcrypt/kdf.h>
 #endif
 
+/* The DES3-CBC code won't compile unless wolfCrypt has support for it. */
+#if defined(NO_DES3) && defined(WE_HAVE_DES3CBC)
+#undef WE_HAVE_DES3CBC
+#endif
+
 #include <wolfengine/we_openssl_bc.h>
 #include <wolfengine/we_logging.h>
 #include <wolfengine/we_fips.h>

--- a/src/we_dh.c
+++ b/src/we_dh.c
@@ -1115,9 +1115,9 @@ static int we_dh_pkey_ctrl_str(EVP_PKEY_CTX *ctx, const char *type,
         /* Set named DH parameters. */
         if (XSTRNCMP(type, "dh_param", 9) == 0) {
         #ifndef HAVE_WC_DHSETNAMEDKEY
-            const DhParams *params;
+            const DhParams *params = NULL;
         #else
-            int params;
+            int params = 0;
         #endif
 
         #ifdef HAVE_PUBLIC_FFDHE

--- a/test/unit.h
+++ b/test/unit.h
@@ -35,6 +35,11 @@
 #include <wolfssl/wolfcrypt/wc_port.h>
 #include <wolfssl/wolfcrypt/rsa.h>
 
+/* The DES3-CBC code won't compile unless wolfCrypt has support for it. */
+#if defined(NO_DES3) && defined(WE_HAVE_DES3CBC)
+#undef WE_HAVE_DES3CBC
+#endif
+
 #include <openssl/engine.h>
 #include <openssl/evp.h>
 #include <openssl/ec.h>


### PR DESCRIPTION
Additionally, fix some warning about using an uninitialized variable in we_dh.c.