### PR TITLE
Fix some macro guards around the ECDSA_METHOD code.

### DIFF
--- a/include/wolfengine/we_internal.h
+++ b/include/wolfengine/we_internal.h
@@ -314,7 +314,7 @@ WOLFENGINE_LOCAL int we_init_ecdh_meth(void);
  */
 
 #ifdef WE_HAVE_ECDSA
-#if OPENSSL_VERSION_NUMBER <= 0x100020ffL
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 
 extern ECDSA_METHOD *we_ecdsa_method;
 WOLFENGINE_LOCAL int we_init_ecdsa_meth(void);

--- a/src/we_ecc.c
+++ b/src/we_ecc.c
@@ -2698,7 +2698,7 @@ int we_init_ecdh_meth(void)
 #endif /* OPENSSL_VERSION_NUMBER < 0x10100000L */
 
 #ifdef WE_HAVE_ECDSA
-#if OPENSSL_VERSION_NUMBER <= 0x100020ffL
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 
 /** ECDSA method - ECDSA using wolfSSL for the implementation. */
 ECDSA_METHOD *we_ecdsa_method = NULL;

--- a/src/we_internal.c
+++ b/src/we_internal.c
@@ -951,7 +951,7 @@ static int wolfengine_init(ENGINE *e)
 #endif /* WE_HAVE_ECDH */
 #endif /* OPENSSL_VERSION_NUMBER < 0x10100000L */
 #ifdef WE_HAVE_ECDSA
-#if OPENSSL_VERSION_NUMBER <= 0x100020ffL
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     if (ret == 1) {
         ret = we_init_ecdsa_meth();
     }
@@ -1278,7 +1278,7 @@ static const ECDH_METHOD *we_ecdh(void)
 #endif /* OPENSSL_VERSION_NUMBER < 0x10100000L */
 
 #ifdef WE_HAVE_ECDSA
-#if OPENSSL_VERSION_NUMBER <= 0x100020ffL
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 /**
  * Return the ECDSA method.
  *
@@ -1345,7 +1345,7 @@ int wolfengine_bind(ENGINE *e, const char *id)
     }
 #endif /* WE_HAVE_DH */
 #ifdef WE_HAVE_ECDSA
-#if OPENSSL_VERSION_NUMBER <= 0x100020ffL
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     if (ret == 1 && ENGINE_set_ECDSA(e, we_ecdsa()) == 0) {
         ret = 0;
     }

--- a/test/test_ecc.c
+++ b/test/test_ecc.c
@@ -2191,7 +2191,7 @@ int test_ecdh_direct_p521(ENGINE* e, void* data)
 
 
 #if defined(WE_HAVE_ECDSA)
-#if OPENSSL_VERSION_NUMBER <= 0x100020ffL
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 
 static int test_ecdsa_sign(EC_KEY *key, unsigned char *hash,
                            size_t hashLen, unsigned char *ecdsaSig,
@@ -2377,7 +2377,7 @@ int test_ecdsa(ENGINE *e, void *data)
     return err;
 }
 
-#endif /* OPENSSL_VERSION_NUMBER <= 0x100020ffL */
+#endif /* OPENSSL_VERSION_NUMBER < 0x10100000L */
 #endif /* WE_HAVE_ECDSA */
 
 #endif /* WE_HAVE_ECC */

--- a/test/unit.c
+++ b/test/unit.c
@@ -335,7 +335,7 @@ TEST_CASE test_case[] = {
 #endif /* WE_HAVE_EC_KEY */
 
 #ifdef WE_HAVE_ECDSA
-#if OPENSSL_VERSION_NUMBER <= 0x100020ffL
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     TEST_DECL(test_ecdsa, NULL),
 #endif
 #endif /* WE_HAVE_ECDSA */


### PR DESCRIPTION
These were guarded by OPENSSL_VERSION_NUMBER <= 0x100020ffL, but ECDSA_METOD
was only removed in 1.1.0, so this guard was compiling out the ECDSA_METHOD code
when building with OpenSSL 1.0.2u.

See ZD 13219.