### PR TITLE
Rework AES-GCM code.

### DIFF
--- a/test/unit.c
+++ b/test/unit.c
@@ -125,6 +125,7 @@ TEST_CASE test_case[] = {
     TEST_DECL(test_aes256_gcm, NULL),
     TEST_DECL(test_aes128_gcm_fixed, NULL),
     TEST_DECL(test_aes128_gcm_tls, NULL),
+    TEST_DECL(test_aes_gcm_evp_cipher, NULL),
 #endif
 #ifdef WE_HAVE_AESCCM
     TEST_DECL(test_aes128_ccm, NULL),

--- a/test/unit.h
+++ b/test/unit.h
@@ -34,6 +34,7 @@
 #endif
 #include <wolfssl/wolfcrypt/wc_port.h>
 #include <wolfssl/wolfcrypt/rsa.h>
+#include <wolfssl/wolfcrypt/aes.h>
 
 /* The DES3-CBC code won't compile unless wolfCrypt has support for it. */
 #if defined(NO_DES3) && defined(WE_HAVE_DES3CBC)
@@ -167,6 +168,7 @@ int test_aes192_gcm(ENGINE *e, void *data);
 int test_aes256_gcm(ENGINE *e, void *data);
 int test_aes128_gcm_fixed(ENGINE *e, void *data);
 int test_aes128_gcm_tls(ENGINE *e, void *data);
+int test_aes_gcm_evp_cipher(ENGINE *e, void *data);
 
 #endif /* WE_HAVE_AESGCM */
 


### PR DESCRIPTION
Defer all encryption/decryption to "final" calls. "Update" calls just cause
the input data and pointer to output buffer to be saved. This was previously
only the behavior for decryption with the macro `WE_AES_GCM_DECRYPT_ON_FINAL`
defined. I've made this the default now, after multiple support inquiries were
resolved by adding the macro to the user's build. I've done the same for
encryption to reduce complexity. I'm also pretty sure the implementation prior
to this commit didn't properly handle the GMAC case, but our tests didn't catch
it. This rework also resolves a curl integration bug discovered in ZD 13387.
Finally, it rids us of the need to cache tag errors, further reducing
complexity.