### PR TITLE
Call wolfCrypt_SetCb_fips in wolfengine_bind for FIPS builds.

### DIFF
--- a/include/wolfengine/we_internal.h
+++ b/include/wolfengine/we_internal.h
@@ -82,7 +82,10 @@
 #include <wolfssl/wolfcrypt/random.h>
 #include <wolfssl/wolfcrypt/pwdbased.h>
 #ifdef HAVE_WOLFSSL_WOLFCRYPT_KDF_H
-    #include <wolfssl/wolfcrypt/kdf.h>
+#include <wolfssl/wolfcrypt/kdf.h>
+#endif
+#ifdef HAVE_FIPS
+#include <wolfssl/wolfcrypt/fips_test.h>
 #endif
 
 /* The DES3-CBC code won't compile unless wolfCrypt has support for it. */

--- a/src/we_internal.c
+++ b/src/we_internal.c
@@ -1311,6 +1311,23 @@ static const ECDSA_METHOD *we_ecdsa(void)
 #endif
 #endif /* WE_HAVE_ECDSA */
 
+#ifdef HAVE_FIPS
+static void we_fips_cb(int ok, int err, const char* hash)
+{
+    printf("*******************************************\n");
+    printf("we_fips_cb: ok = %d, err = %d\n", ok, err);
+    printf("error message = %s\n", wc_GetErrorString(err));
+    printf("hash = %s\n", hash);
+
+    if (err == IN_CORE_FIPS_E) {
+        printf("FIPS module integrity check failure. Copy above hash value "
+               "into verifyCore[] in wolfSSL's (NOT wolfEngine) fips_test.c "
+               "and rebuild wolfSSL.\n");
+    }
+    printf("*******************************************\n");
+}
+#endif
+
 /**
  * Bind the wolfengine into an engine object.
  *
@@ -1323,6 +1340,10 @@ int wolfengine_bind(ENGINE *e, const char *id)
     int ret = 1;
 
     WOLFENGINE_ENTER(WE_LOG_ENGINE, "wolfengine_bind");
+
+#ifdef HAVE_FIPS
+    wolfCrypt_SetCb_fips(we_fips_cb);
+#endif
 
     if ((id != NULL) &&
                  (XSTRNCMP(id, wolfengine_id, XSTRLEN(wolfengine_id)) != 0)) {


### PR DESCRIPTION
We've had a lot of users come to us for support when wolfEngine can't be found,
and the resolution often ends up being that the FIPS module integrity check
failed and the expected HMAC value needs to be updated. This commit sets up
a callback that will indicate the problem and how to fix it, just like we do
for testwolfcrypt in wolfSSL.