### PR TITLE
Makefile.am: fix build on an external directory

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -38,6 +38,8 @@ AM_DISTCHECK_CONFIGURE_FLAGS=CPPFLAGS="-I@abs_top_srcdir@/include \
                                          @OPENSSL_INCLUDES@" \
                              LDFLAGS="@OPENSSL_LDFLAGS@"
 
+AM_CPPFLAGS = -I$(top_srcdir)/include
+
 EXTRA_DIST+= README.md
 
 EXTRA_DIST += \


### PR DESCRIPTION
Doing external build of the repository fails due to not finding some
header files:

fatal error: wolfengine/we_internal.h: No such file or directory

This is what happens for example in Yocto, where the packages are not
build in the source tree itself but in an external build directory.

Signed-off-by: Javier Viguera <javier.viguera@digi.com>