### PR TITLE
Fix AES-CTR leftover data issue.

### DIFF
--- a/test/unit.c
+++ b/test/unit.c
@@ -117,6 +117,7 @@ TEST_CASE test_case[] = {
     TEST_DECL(test_aes128_ctr_stream, NULL),
     TEST_DECL(test_aes192_ctr_stream, NULL),
     TEST_DECL(test_aes256_ctr_stream, NULL),
+    TEST_DECL(test_aes_ctr_leftover_data_regression, NULL),
     TEST_DECL(test_aes_ctr_iv_init_regression, NULL),
 #endif
 #ifdef WE_HAVE_AESGCM

--- a/test/unit.h
+++ b/test/unit.h
@@ -157,7 +157,8 @@ int test_aes128_ctr_stream(ENGINE *e, void *data);
 int test_aes192_ctr_stream(ENGINE *e, void *data);
 int test_aes256_ctr_stream(ENGINE *e, void *data);
 
-int test_aes_ctr_iv_init_regression(ENGINE *, void *);
+int test_aes_ctr_leftover_data_regression(ENGINE *e, void *data);
+int test_aes_ctr_iv_init_regression(ENGINE *e, void *data);
 
 #endif
 


### PR DESCRIPTION
A customer discovered a problem with our AES-CTR implementation where partial block data from a prior AES-CTR operation was being mixed in with a subsequent operation's input data, even when the IV was being changed between. This is a known problem with wc_AesSetIV, where it doesn't clear the `left` field. This commit makes sure we clear `left` on init calls, among some other changes:

- Add always call init flag.
- Set Aes object to 0s on first init.
- In init, call wc_AesSetIV when IV isn't NULL. When setting key, ensure that we don't wipe out a previously set IV with wc_AesSetKey. This change allows us to remove the wc_AesSetIV call in we_aes_ctr_cipher.
- we_aes_ctr_cipher should return 0 when in == NULL.