### PR TITLE
Make improvements to RNG code in we_random.c.

### DIFF
--- a/include/wolfengine/we_internal.h
+++ b/include/wolfengine/we_internal.h
@@ -62,6 +62,7 @@
 #include <openssl/cmac.h>
 #endif
 #include <openssl/pkcs12.h>
+#include <openssl/crypto.h>
 
 #ifndef WOLFENGINE_USER_SETTINGS
 #include <wolfssl/options.h>


### PR DESCRIPTION
Remove we_rand_bytes and always use we_rand_pseudorand for RAND_METHOD's "bytes" function. we_rand_bytes was using wc_GenerateSeed to provide true entropy for older versions of OpenSSL. With this commit, both the bytes and pseudorand members of wolfEngine's RAND_METHOD map to the same function, which was already the case if using wolfEngine with an OpenSSL version after 1.1.0. This commit renames we_rand_pseudorand to we_rand_bytes.

Additionally, I've augmented the new unified function to mix in the thread ID, a timer value, and PID to add some additional weak entropy. These changes resolve an issue with OpenSSH where we_rand_bytes was being called in a forked process that didn't have the ability to open /dev/urandom, which wc_GenerateSeed will attempt to do.