### PR TITLE
Allow private key read on created Windows threads in multithreaded environment

### DIFF
--- a/src/we_internal.c
+++ b/src/we_internal.c
@@ -1463,3 +1463,23 @@ int wolfengine_bind(ENGINE *e, const char *id)
 
     return ret;
 }
+
+#if !defined(WE_SINGLE_THREADED) && defined(_WIN32)
+/**
+ * Windows DLL entry point when wolfEngine build as a DLL.
+ *
+ * Called for DLL process or thread events, such as creation (attach).
+ *
+ * @param hinstDLL    [IN]  A handle to the DLL module.
+ * @param fdwReason   [IN]  Reason why funciton being called.
+ * @param lpvReserved [IN]  Reason-dependent extra data.
+ * @returns TRUE always
+ */
+BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
+{
+    if (fdwReason == DLL_THREAD_ATTACH) {
+        wolfCrypt_SetPrivateKeyReadEnable_fips(1, WC_KEYTYPE_ALL);
+    }
+    return TRUE;
+}
+#endif /* !WE_SINGLE_THREADED && _WIN32 */

--- a/src/we_internal.c
+++ b/src/we_internal.c
@@ -1464,14 +1464,14 @@ int wolfengine_bind(ENGINE *e, const char *id)
     return ret;
 }
 
-#if !defined(WE_SINGLE_THREADED) && defined(_WIN32)
+#if !defined(WE_SINGLE_THREADED) && defined(_WIN32) && defined(HAVE_FIPS_VERSION) && HAVE_FIPS_VERSION == 5
 /**
- * Windows DLL entry point when wolfEngine build as a DLL.
+ * Windows DLL entry point when wolfEngine built as a DLL.
  *
  * Called for DLL process or thread events, such as creation (attach).
  *
  * @param hinstDLL    [IN]  A handle to the DLL module.
- * @param fdwReason   [IN]  Reason why funciton being called.
+ * @param fdwReason   [IN]  Reason why function being called.
  * @param lpvReserved [IN]  Reason-dependent extra data.
  * @returns TRUE always
  */
@@ -1482,4 +1482,4 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
     }
     return TRUE;
 }
-#endif /* !WE_SINGLE_THREADED && _WIN32 */
+#endif /* !WE_SINGLE_THREADED && _WIN32 && HAVE_FIPS_VERSION && HAVE_FIPS_VERSION 5 */

--- a/test/test_dh.c
+++ b/test/test_dh.c
@@ -347,6 +347,7 @@ typedef struct {
     EVP_PKEY* params;
 } DH_KEYGEN_THREAD_VARS;
 
+/* Windows thread entry function which will test private key read access. */
 static DWORD WINAPI DhKeyGenThreadFunc(LPVOID arg)
 {
     DH_KEYGEN_THREAD_VARS* vars = (DH_KEYGEN_THREAD_VARS*)arg;

--- a/test/test_dh.c
+++ b/test/test_dh.c
@@ -342,6 +342,8 @@ int test_dh_pgen_pkey(ENGINE *e, void *data)
 
 #if !defined(WE_SINGLE_THREADED) && defined(_WIN32)
 
+#define TEST_MT_TIMEOUT 5000 /* Multi-threaded test timeout (ms) */
+
 typedef struct {
     ENGINE* e;
     EVP_PKEY* params;
@@ -366,8 +368,7 @@ int test_dh_key_gen_multithreaded(ENGINE* e, EVP_PKEY* params)
     int err = 1;
 
     thread = CreateThread(NULL, 0, DhKeyGenThreadFunc, &vars, 0, NULL);
-    if (thread) {
-        WaitForSingleObject(thread, INFINITE);
+    if (thread && (WaitForSingleObject(thread, TEST_MT_TIMEOUT) == WAIT_OBJECT_0)) {
         err = (GetExitCodeThread(thread, &threadErr) == 0 ? 1 : threadErr);
         CloseHandle(thread);
     }

--- a/test/test_dh.c
+++ b/test/test_dh.c
@@ -368,14 +368,7 @@ int test_dh_key_gen_multithreaded(ENGINE* e, EVP_PKEY* params)
     vars.e = e;
     vars.params = params;
 
-    hThread = CreateThread(
-        NULL,
-        0,
-        DhKeyGenThreadFunc,
-        &vars,
-        0,
-        &dwThreadId);
-
+    hThread = CreateThread(NULL, 0, DhKeyGenThreadFunc, &vars, 0, &dwThreadId);
     if (hThread == NULL) {
         err = 1;
     }

--- a/test/test_dh.c
+++ b/test/test_dh.c
@@ -362,7 +362,6 @@ int test_dh_key_gen_multithreaded(ENGINE* e, EVP_PKEY* params)
     DH_KEYGEN_THREAD_VARS vars;
     HANDLE hThread;
     DWORD dwThreadId;
-
     DWORD dwThreadErr = 0;
     int err = 0;
 

--- a/test/unit.c
+++ b/test/unit.c
@@ -152,6 +152,9 @@ TEST_CASE test_case[] = {
 #ifdef WE_HAVE_EVP_PKEY
     TEST_DECL(test_dh_pgen_pkey, NULL),
     TEST_DECL(test_dh_pkey, NULL),
+#if !defined(WE_SINGLE_THREADED) && defined(_WIN32)
+    TEST_DECL(test_dh_key_gen_multithreaded, NULL),
+#endif /* !WE_SINGLE_THREADED && _WIN32 */
 #endif /* WE_HAVE_EVP_PKEY */
 #endif /* WE_HAVE_DH */
 #if OPENSSL_VERSION_NUMBER < 0x10100000L

--- a/test/unit.h
+++ b/test/unit.h
@@ -248,6 +248,9 @@ int test_dh(ENGINE *e, void *data);
 #ifdef WE_HAVE_EVP_PKEY
 int test_dh_pgen_pkey(ENGINE *e, void *data);
 int test_dh_pkey(ENGINE *e, void *data);
+#if !defined(WE_SINGLE_THREADED) && defined(_WIN32)
+int test_dh_key_gen_multithreaded(ENGINE *e, void *data);
+#endif /* !WE_SINGLE_THREADED && _WIN32 */
 #endif /* WE_HAVE_EVP_PKEY */
 #endif /* WE_HAVE_DH */
 


### PR DESCRIPTION
Related to ZenDesk 14679 - In a Windows multi-threaded environment new threads did not have the private key read enable thread-local storage value updated, leading to problems with key access from created threads.

Fix based on suggestion in ZenDesk ticket, verified in Windows environment using new test.

**Changes**

- Added logic to allow private key read on created threads in Windows multi-threaded configuration via addition of minimal `DllMain() `function to update new thread's TLS value.
- Added new test for private key access on created threads.

