### PR TITLE
Fix some issues discovered when running ruby OpenSSL gem tests.

### DIFF
--- a/include/wolfengine/we_openssl_bc.h
+++ b/include/wolfengine/we_openssl_bc.h
@@ -200,6 +200,11 @@ size_t EC_POINT_point2buf(const EC_GROUP *group, const EC_POINT *point,
 #define EVP_PKEY_ECDH_KDF_X9_63     EVP_PKEY_ECDH_KDF_X9_62
 #endif
 
+#ifndef EVP_PKEY_CTRL_DH_PAD
+/* First defined in OPENSSL_VERSION_NUMBER == 0x10101001L. */
+#define EVP_PKEY_CTRL_DH_PAD (EVP_PKEY_ALG_CTRL + 16)
+#endif
+
 WOLFENGINE_LOCAL const BIGNUM *DH_get0_p(const DH *dh);
 WOLFENGINE_LOCAL const BIGNUM *DH_get0_g(const DH *dh);
 WOLFENGINE_LOCAL const BIGNUM *DH_get0_q(const DH *dh);

--- a/test/unit.c
+++ b/test/unit.c
@@ -153,6 +153,7 @@ TEST_CASE test_case[] = {
 #ifdef WE_HAVE_EVP_PKEY
     TEST_DECL(test_dh_pgen_pkey, NULL),
     TEST_DECL(test_dh_pkey, NULL),
+    TEST_DECL(test_dh_ctrl, NULL),
 #if !defined(WE_SINGLE_THREADED) && defined(_WIN32)
     TEST_DECL(test_dh_key_gen_multithreaded, NULL),
 #endif /* !WE_SINGLE_THREADED && _WIN32 */

--- a/test/unit.h
+++ b/test/unit.h
@@ -249,6 +249,7 @@ int test_dh(ENGINE *e, void *data);
 #ifdef WE_HAVE_EVP_PKEY
 int test_dh_pgen_pkey(ENGINE *e, void *data);
 int test_dh_pkey(ENGINE *e, void *data);
+int test_dh_ctrl(ENGINE *e, void *data);
 #if !defined(WE_SINGLE_THREADED) && defined(_WIN32)
 int test_dh_key_gen_multithreaded(ENGINE *e, void *data);
 #endif /* !WE_SINGLE_THREADED && _WIN32 */


### PR DESCRIPTION
- If length param to rand bytes function is 0, do nothing and return success.
- In we_dh_compute_key_int, if DH_get0_priv_key returns NULL, error out. The lack of NULL check here was causing a seg fault.
- Add support for the dh_paramgen_prime_len control string in DH code.
- Receiving EVP_PKEY_CTRL_DH_PARAMGEN_GENERATOR should return an error, since we don't support setting the generator.
- Add a DH control command unit test.

See ZD #14805.