### PR TITLE
Support -1 HMAC key length

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,14 @@ as described earlier.
 See the scripts directory for integration tests with other applications (e.g.
 OpenSSH, stunnel, etc.).
 
+### Commit Tests
+
+For wolfEngine developers running commit tests, a custom OpenSSL installation
+location can be set using the `WOLFENGINE_OPENSSL_INSTALL` environment variable.
+When set, wolfEngine commit tests will use the specified OpenSSL installation
+path for commit tests, setting the path using
+`--with-openssl=WOLFENGINE_OPENSSL_INSTALL` at configure time.
+
 ## Windows
 
 Refer to `windows/README.md` for instructions for building wolfEngine using

--- a/src/we_mac.c
+++ b/src/we_mac.c
@@ -464,7 +464,11 @@ static int we_mac_pkey_ctrl(EVP_PKEY_CTX *ctx, int type, int num, void *ptr)
                  * num  [in]  Length of key in bytes.
                  */
                 WOLFENGINE_MSG(WE_LOG_MAC, "type: EVP_PKEY_CTRL_SET_MAC_KEY");
-                if (ptr != NULL && num >= 0) {
+                if (ptr != NULL && num >= -1) {
+                    if (num == -1) {
+                        /* App can pass -1 length, must use strlen() */
+                        num = (int)XSTRLEN(ptr);
+                    }
                     ret = we_mac_set_key(mac, ptr, num);
                 }
                 else {

--- a/test/test_hmac.c
+++ b/test/test_hmac.c
@@ -135,45 +135,71 @@ int test_hmac_create(ENGINE *e, void *data)
     if (ret == 0) {
         PRINT_MSG("Testing with SHA224");
         ret = test_hmac_create_helper(e, data, EVP_sha224(), pswd, sizeof(pswd));
+        if (ret == 0) {
+            /* EVP_PKEY_new_mac_key() can be called with -1, OpenSSL expects
+             * engine implementations to use strlen() to find string length */
+            ret = test_hmac_create_helper(e, data, EVP_sha224(), pswd, -1);
+        }
     }
 
     if (ret == 0) {
         PRINT_MSG("Testing with SHA256");
         ret = test_hmac_create_helper(e, data, EVP_sha256(), pswd, sizeof(pswd));
+        if (ret == 0) {
+            ret = test_hmac_create_helper(e, data, EVP_sha256(), pswd, -1);
+        }
     }
 
     if (ret == 0) {
         PRINT_MSG("Testing with SHA384");
         ret = test_hmac_create_helper(e, data, EVP_sha384(), pswd, sizeof(pswd));
+        if (ret == 0) {
+            ret = test_hmac_create_helper(e, data, EVP_sha384(), pswd, -1);
+        }
     }
 
     if (ret == 0) {
         PRINT_MSG("Testing with SHA512");
         ret = test_hmac_create_helper(e, data, EVP_sha512(), pswd, sizeof(pswd));
+        if (ret == 0) {
+            ret = test_hmac_create_helper(e, data, EVP_sha512(), pswd, -1);
+        }
     }
 
 #ifdef WE_HAVE_SHA3_224
     if (ret == 0) {
         PRINT_MSG("Testing with SHA3-224");
         ret = test_hmac_create_helper(e, data, EVP_sha3_224(), pswd, sizeof(pswd));
+        if (ret == 0) {
+            ret = test_hmac_create_helper(e, data, EVP_sha3_224(), pswd, -1);
+        }
     }
 #endif
 #ifdef WE_HAVE_SHA3_256
     if (ret == 0) {
         PRINT_MSG("Testing with SHA3-256");
         ret = test_hmac_create_helper(e, data, EVP_sha3_256(), pswd, sizeof(pswd));
+        if (ret == 0) {
+            ret = test_hmac_create_helper(e, data, EVP_sha3_256(), pswd, -1);
+        }
     }
 #endif
 #ifdef WE_HAVE_SHA3_384
     if (ret == 0) {
         PRINT_MSG("Testing with SHA3-384");
         ret = test_hmac_create_helper(e, data, EVP_sha3_384(), pswd, sizeof(pswd));
+        if (ret == 0) {
+            ret = test_hmac_create_helper(e, data, EVP_sha3_384(), pswd, -1);
+        }
     }
 #endif
 #ifdef WE_HAVE_SHA3_512
     if (ret == 0) {
         PRINT_MSG("Testing with SHA3-512");
         ret = test_hmac_create_helper(e, data, EVP_sha3_512(), pswd, sizeof(pswd));
+        if (ret == 0) {
+            ret = test_hmac_create_helper(e, data, EVP_sha3_512(), pswd, -1);
+        }
     }
 #endif
     return ret;


### PR DESCRIPTION
This PR adds support for OpenSSL HMAC callers to use `-1` as the key length. OpenSSL allows this, and expects engine implementations to use `strlen()` on the provided key to get the length in this case.

Edge case detected by a customer when running the following OpenSSL command line application call:

```
echo -ne "TEST_MESSAGE" | openssl sha256 -hmac "TestKeyStringHere"
```

This PR also adds HMAC unit tests for `-1` cases and updates the `README.md` with a note about the `WOLFENGINE_OPENSSL_INSTALL` environment variable for commit tests.