### PR TITLE
Fix build errors

### DIFF
--- a/src/we_ecc.c
+++ b/src/we_ecc.c
@@ -921,7 +921,7 @@ static int we_ec_keygen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
 
     if (ret == 1 && ecc->group == NULL) {
         const EC_GROUP *group;
-        EC_KEY *tmp;
+        const EC_KEY *tmp;
 
         /* set group from the ctx pkey */
         tmp = EVP_PKEY_get0_EC_KEY(ctxPkey);

--- a/src/we_rsa.c
+++ b/src/we_rsa.c
@@ -208,9 +208,11 @@ static int we_pss_salt_len_to_wc(int saltLen, const EVP_MD *md, RsaKey *key,
             if (signing) {
                 saltLen = wc_RsaEncryptSize(key) - EVP_MD_size(md) - 2;
             }
+            #ifdef WOLFSSL_PSS_SALT_LEN_DISCOVER
             else {
                 saltLen = RSA_PSS_SALT_LEN_DISCOVER;
             }
+            #endif
         #endif
         }
     }


### PR DESCRIPTION
All uses of `RSA_PSS_SALT_LEN_DISCOVER` should be guarded by `WOLFSSL_PSS_SALT_LEN_DISCOVER`

Fixes ZD15976

