### PR TITLE
Version Changes

### DIFF
--- a/src/we_ecc.c
+++ b/src/we_ecc.c
@@ -1440,7 +1440,7 @@ static int we_ec_ctrl_str(EVP_PKEY_CTX *ctx, const char *type,
     return ret;
 }
 
-#if OPENSSL_VERSION_NUMBER >= 0x10101000L
+#if OPENSSL_VERSION_NUMBER >= 0x1000212fL
 /**
  * Used to set the group
  *
@@ -1550,7 +1550,7 @@ int we_init_ecc_meths(void)
         EVP_PKEY_meth_set_copy(we_ec_method, we_ec_copy);
         EVP_PKEY_meth_set_cleanup(we_ec_method, we_ec_cleanup);
 
-#if OPENSSL_VERSION_NUMBER >= 0x10101000L
+#if OPENSSL_VERSION_NUMBER >= 0x1000212fL
         /* used in TLS 1.3 connections */
         EVP_PKEY_meth_set_paramgen(we_ec_method, NULL, wc_ec_paramgen);
 #endif

--- a/src/we_mac.c
+++ b/src/we_mac.c
@@ -1509,6 +1509,8 @@ static int we_cmac_pkey_keygen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
     #if OPENSSL_VERSION_NUMBER >= 0x10101000L
         /* Set alias to distinguish between OpenSSL and wolfEngine created. */
         ret = EVP_PKEY_set_alias_type(pkey, NID_wolfengine_cmac);
+    #else
+        pkey->type = NID_wolfengine_cmac;
     #endif
     }
 
@@ -1529,7 +1531,7 @@ static void we_cmac_pkey_free(EVP_PKEY *pkey)
     WOLFENGINE_MSG_VERBOSE(WE_LOG_MAC, "ARGS [pkey = %p]", pkey);
 
     /* Can be either local alias or CMAC with OpenSSL data. */
-#if OPENSSL_VERSION_NUMBER >= 0x10101000L
+#if OPENSSL_VERSION_NUMBER >= 0x1000212fL
     if (EVP_PKEY_id(pkey) == NID_wolfengine_cmac)
 #endif
     {
@@ -1547,7 +1549,7 @@ static void we_cmac_pkey_free(EVP_PKEY *pkey)
             ret = 0;
         }
     }
-#if OPENSSL_VERSION_NUMBER >= 0x10101000L
+#if OPENSSL_VERSION_NUMBER >= 0x1000212fL
     else {
         CMAC_CTX *cmac;
 


### PR DESCRIPTION
Updated ECC and MAC modules to allow v1.0.2r of OpenSSL to use some functions and behavior.