### PR TITLE
Unlock private key access for export in we_ec_export_key

### DIFF
--- a/src/we_ecc.c
+++ b/src/we_ecc.c
@@ -238,7 +238,9 @@ static int we_ec_export_key(ecc_key *ecc, int len, EC_KEY *key)
 
         d = y + len;
         /* Export public and private key data. */
+        PRIVATE_KEY_UNLOCK();
         rc = wc_ecc_export_private_raw(ecc, x, &xLen, y, &yLen, d, &dLen);
+        PRIVATE_KEY_LOCK();
         if (rc != 0) {
             WOLFENGINE_ERROR_FUNC(WE_LOG_PK, "wc_ecc_export_private", rc);
             ret = 0;


### PR DESCRIPTION
## Problem

When wolfSSL is built as a FIPS 140-3 module (e.g. `--enable-engine=fips-ready`), the private key access lock causes `wc_ecc_export_private_raw()` in `we_ec_export_key()` to fail with `FIPS_PRIVATE_KEY_LOCKED_E` (-287). This breaks all EC key generation through the engine, including ECDHE ephemeral key generation during TLS handshakes.

## Fix

Wrap the call with `PRIVATE_KEY_UNLOCK()` / `PRIVATE_KEY_LOCK()`, matching the existing handling of the other private key export paths (`we_rsa.c`, `we_dh.c`, `we_pbe.c`, and the remaining paths in `we_ecc.c`). The macros are no-ops for non-FIPS wolfSSL builds.

## Testing

Against wolfSSL 5.9.1 `--enable-engine=fips-ready` (FIPS Ready 140-3, wolfCrypt v7) + OpenSSL 1.1.1b:

- Before: unit tests for EC key generation (`test_ec_key_keygen_*` / `test_ec_key_ecdh_*_keygen`, P-256/P-384/P-521) fail with `wc_ecc_export_private: ret = -287`.
- After: full unit suite passes.

Also verified against a non-FIPS wolfSSL build (no behavior change).