### PR TITLE
Fix clang warning errors

### DIFF
--- a/src/we_aes_block.c
+++ b/src/we_aes_block.c
@@ -321,7 +321,7 @@ static int we_init_aescbc_meth(EVP_CIPHER *cipher)
  *
  * @return  1 on success and 0 on failure.
  */
-int we_init_aescbc_meths()
+int we_init_aescbc_meths(void)
 {
     int ret = 1;
 
@@ -805,7 +805,7 @@ static int we_init_aesecb_meth(EVP_CIPHER *cipher)
  *
  * @return  1 on success and 0 on failure.
  */
-int we_init_aesecb_meths()
+int we_init_aesecb_meths(void)
 {
     int ret = 1;
 

--- a/src/we_aes_cbc_hmac.c
+++ b/src/we_aes_cbc_hmac.c
@@ -568,7 +568,7 @@ static int we_init_aescbc_hmac_meth(EVP_CIPHER *cipher)
  *
  * @return  1 on success and 0 on failure.
  */
-int we_init_aescbc_hmac_meths()
+int we_init_aescbc_hmac_meths(void)
 {
     int ret = 1;
 

--- a/src/we_aes_ccm.c
+++ b/src/we_aes_ccm.c
@@ -673,7 +673,7 @@ static int we_init_aesccm_meth(EVP_CIPHER *cipher)
  *
  * @return  1 on success and 0 on failure.
  */
-int we_init_aesccm_meths()
+int we_init_aesccm_meths(void)
 {
     int ret = 1;
 

--- a/src/we_aes_ctr.c
+++ b/src/we_aes_ctr.c
@@ -274,7 +274,7 @@ static int we_init_aesctr_meth(EVP_CIPHER *cipher)
  *
  * @return  1 on success and 0 on failure.
  */
-int we_init_aesctr_meths()
+int we_init_aesctr_meths(void)
 {
     int ret = 1;
 

--- a/src/we_aes_gcm.c
+++ b/src/we_aes_gcm.c
@@ -71,9 +71,9 @@ typedef struct we_AesGcm
     /** Flag to indicate whether dping this for TLS */
     unsigned int   tls:1;
     /** IV set. */
-    int            ivSet:1;
+    unsigned int   ivSet:1;
     /** IV increment. */
-    int            ivInc:1;
+    unsigned int   ivInc:1;
 } we_AesGcm;
 
 /**
@@ -828,7 +828,7 @@ static int we_init_aesgcm_meth(EVP_CIPHER *cipher)
  *
  * @return  1 on success and 0 on failure.
  */
-int we_init_aesgcm_meths()
+int we_init_aesgcm_meths(void)
 {
     int ret = 1;
 

--- a/src/we_des3_cbc.c
+++ b/src/we_des3_cbc.c
@@ -360,7 +360,7 @@ static int we_init_des3cbc_meth(EVP_CIPHER *cipher)
  *
  * @return  1 on success and 0 on failure.
  */
-int we_init_des3cbc_meths()
+int we_init_des3cbc_meths(void)
 {
     int ret = 1;
 

--- a/src/we_dh.c
+++ b/src/we_dh.c
@@ -51,9 +51,9 @@ typedef struct we_Dh
     /** Length of "q" in bytes. */
     int qLen;
     /** Pad the secret output. */
-    int pad:1;
+    unsigned int pad:1;
     /** Named group set. */
-    int named:1;
+    unsigned int named:1;
 } we_Dh;
 
 /** DH key method - DH using wolfSSL for the implementation. */

--- a/src/we_digest.c
+++ b/src/we_digest.c
@@ -135,7 +135,7 @@ EVP_MD *we_sha1_md = NULL;
  *
  * @return  1 on success else failure.
  */
-int we_init_sha_meth()
+int we_init_sha_meth(void)
 {
     int ret;
 
@@ -288,7 +288,7 @@ EVP_MD *we_sha224_md = NULL;
  *
  * @return  1 on success else failure.
  */
-int we_init_sha224_meth()
+int we_init_sha224_meth(void)
 {
     int ret;
 
@@ -441,7 +441,7 @@ EVP_MD *we_sha256_md = NULL;
  *
  * @return  1 on success else failure.
  */
-int we_init_sha256_meth()
+int we_init_sha256_meth(void)
 {
     int ret;
 
@@ -1003,7 +1003,7 @@ EVP_MD *we_sha1_md = NULL;
  *
  * @return  1 on success else failure.
  */
-int we_init_sha_meth()
+int we_init_sha_meth(void)
 {
     int ret;
 
@@ -1046,7 +1046,7 @@ EVP_MD *we_ecdsa_sha1_md = NULL;
  *
  * @return  1 on success else failure.
  */
-int we_init_ecdsa_sha1_meth()
+int we_init_ecdsa_sha1_meth(void)
 {
     int ret;
 
@@ -1084,7 +1084,7 @@ EVP_MD *we_sha224_md = NULL;
  *
  * @return  1 on success else failure.
  */
-int we_init_sha224_meth()
+int we_init_sha224_meth(void)
 {
     int ret;
 
@@ -1124,7 +1124,7 @@ EVP_MD *we_sha256_md = NULL;
  *
  * @return  1 on success else failure.
  */
-int we_init_sha256_meth()
+int we_init_sha256_meth(void)
 {
     int ret;
 
@@ -1164,7 +1164,7 @@ EVP_MD *we_sha384_md = NULL;
  *
  * @return  1 on success else failure.
  */
-int we_init_sha384_meth()
+int we_init_sha384_meth(void)
 {
     int ret;
 
@@ -1204,7 +1204,7 @@ EVP_MD *we_sha512_md = NULL;
  *
  * @return  1 on success else failure.
  */
-int we_init_sha512_meth()
+int we_init_sha512_meth(void)
 {
     int ret = 1;
 
@@ -1244,7 +1244,7 @@ EVP_MD *we_sha3_224_md = NULL;
  *
  * @return  1 on success else failure.
  */
-int we_init_sha3_224_meth()
+int we_init_sha3_224_meth(void)
 {
     int ret = 1;
 
@@ -1286,7 +1286,7 @@ EVP_MD *we_sha3_256_md = NULL;
  *
  * @return  1 on success else failure.
  */
-int we_init_sha3_256_meth()
+int we_init_sha3_256_meth(void)
 {
     int ret = 1;
 
@@ -1328,7 +1328,7 @@ EVP_MD *we_sha3_384_md = NULL;
  *
  * @return  1 on success else failure.
  */
-int we_init_sha3_384_meth()
+int we_init_sha3_384_meth(void)
 {
     int ret = 1;
 
@@ -1370,7 +1370,7 @@ EVP_MD *we_sha3_512_md = NULL;
  *
  * @return  1 on success else failure.
  */
-int we_init_sha3_512_meth()
+int we_init_sha3_512_meth(void)
 {
     int ret = 1;
 

--- a/src/we_ecc.c
+++ b/src/we_ecc.c
@@ -300,12 +300,12 @@ typedef struct we_Ecc
     EC_GROUP      *group;
 #endif
     /** Indicates private key has been set into wolfSSL structure. */
-    int            privKeySet:1;
+    unsigned int   privKeySet:1;
     /** Indicates public key has been set into wolfSSL structure. */
-    int            pubKeySet:1;
+    unsigned int   pubKeySet:1;
 #ifdef WE_HAVE_ECDH
     /** Use co-factor with ECDH operation. */
-    int            coFactor:1;
+    unsigned int   coFactor:1;
     /** Type of KDF to use with ECDH derivation. */
     int            kdfType;
     /** Digest method to use with KDF. */

--- a/src/we_fips.c
+++ b/src/we_fips.c
@@ -44,7 +44,7 @@ void wolfEngine_SetFipsChecks(long checksMask)
  *
  * @return  The FIPS checks mask.
  */
-long wolfEngine_GetFipsChecks()
+long wolfEngine_GetFipsChecks(void)
 {
     return fipsChecks;
 }

--- a/src/we_pbe.c
+++ b/src/we_pbe.c
@@ -510,7 +510,7 @@ static int we_pbes2_keyivgen(EVP_CIPHER_CTX *ctx, const char *passwd,
  *
  * @returns  1 on success and 0 on failure.
  */
-int we_init_pbe_keygen()
+int we_init_pbe_keygen(void)
 {
 #ifndef NO_PWDBASED
     int ret;

--- a/src/we_rsa.c
+++ b/src/we_rsa.c
@@ -68,11 +68,11 @@ typedef struct we_Rsa
     /** Length of salt to use with PSS. */
     int saltLen;
     /** Indicates private key has been set into wolfSSL structure. */
-    int privKeySet:1;
+    unsigned int privKeySet:1;
     /** Indicates public key has been set into wolfSSL structure. */
-    int pubKeySet:1;
+    unsigned int pubKeySet:1;
     /** Indicates message digest algorithm has been explicitly set. */
-    int mdSet:1;
+    unsigned int mdSet:1;
 } we_Rsa;
 
 

--- a/test/test_tls1_prf.c
+++ b/test/test_tls1_prf.c
@@ -29,7 +29,7 @@ static int test_tls1_prf_calc(ENGINE *e, unsigned char *key, int keyLen,
     int err = 0;
     EVP_PKEY_CTX *ctx = NULL;
     unsigned char secret[32] = { 0, };
-    unsigned char label[5] = "Label";
+    unsigned char label[5] = { 'L', 'a', 'b', 'e', 'l' };
     unsigned char seed[32] = { 0, };
     size_t len = keyLen;
 

--- a/test/unit.h
+++ b/test/unit.h
@@ -78,10 +78,10 @@ typedef struct TEST_CASE {
     TEST_FUNC   func;
     void       *data;
     int         err;
-    int         run:1;
-    int         done:1;
+    unsigned int run:1;
+    unsigned int done:1;
 #ifdef TEST_MULTITHREADED
-    int         attempted:1;
+    unsigned int attempted:1;
     pthread_t   thread;
     int         cnt;
 #endif


### PR DESCRIPTION
Fix clang -Werror failures from signed one-bit bitfields, old-style no-arg definitions, and a TLS1_PRF fixed-size string initializer.

Validation:
- make -j$(nproc)
- make V=1 test/test_tls1_prf.o
- ./test/unit.test 13 with LD_LIBRARY_PATH set for local OpenSSL/wolfSSL

Note: full make check still hits existing ECC keygen failures on master without the separate ECC unlock fix.