### PR TITLE
feat: add make sbom / install-sbom / uninstall-sbom targets

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ 'master', 'main', 'release/**' ]
   pull_request:
-    branches: [ '*' ]
+    branches: [ '**' ]
   workflow_dispatch:
     inputs:
       wolfssl_ref:

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,207 @@
+name: SBOM Test
+
+on:
+  push:
+    branches: [ 'master', 'main', 'release/**' ]
+  pull_request:
+    branches: [ '*' ]
+  workflow_dispatch:
+    inputs:
+      wolfssl_ref:
+        description: 'wolfssl git ref that provides scripts/gen-sbom'
+        # TODO: switch back to 'master' once wolfSSL/wolfssl#10343 merges.
+        default: 'refs/pull/10343/head'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# This workflow only reads the repo and uploads artefacts; no API writes.
+permissions:
+  contents: read
+
+jobs:
+  sbom:
+    name: wolfEngine SBOM generation (linux)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout wolfengine
+        uses: actions/checkout@v4
+        with:
+          path: wolfengine
+
+      # wolfEngine links both wolfSSL and OpenSSL, so its SBOM records both as
+      # dependencies.  wolfSSL is built + installed here so wolfEngine has a
+      # library to link, and the same source tree (scripts/gen-sbom +
+      # wolfssl/version.h) is passed to `make sbom` via WOLFSSL_DIR -- so the
+      # recorded wolfSSL dependency version matches the linked one.  gen-sbom is
+      # not yet on wolfssl master, so default to the open PR head that carries it
+      # (wolfSSL/wolfssl#10343) so CI actually exercises `make sbom` (with
+      # --dep-wolfssl / --dep-openssl) instead of silently skipping.  TODO:
+      # switch the fallback back to 'master' once #10343 merges.
+      - name: Checkout wolfssl (gen-sbom + library source)
+        uses: actions/checkout@v4
+        with:
+          repository: wolfSSL/wolfssl
+          ref: ${{ github.event.inputs.wolfssl_ref || 'refs/pull/10343/head' }}
+          path: wolfssl
+
+      - name: Install build tooling, OpenSSL dev, SBOM validator
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential autoconf automake libtool \
+              pkg-config libssl-dev
+          python3 -m pip install --user 'spdx-tools==0.8.*'
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      # --enable-engine=no-fips is wolfEngine's documented wolfSSL build option
+      # (README "From Git").
+      - name: Build and install wolfssl
+        working-directory: wolfssl
+        run: |
+          autoreconf -ivf || ./autogen.sh
+          ./configure --enable-engine=no-fips \
+              --prefix="$GITHUB_WORKSPACE/wolfssl-install"
+          make -j"$(nproc)"
+          make install
+
+      # gen-sbom lives in wolfssl and may not be on the checked-out ref yet (the
+      # wolfSSL SBOM change can land separately).  Gate on its presence and on
+      # the --dep-wolfssl / --dep-openssl capabilities so this workflow is safe
+      # even against a gen-sbom that predates them.
+      - name: Detect gen-sbom availability and capabilities
+        id: gate
+        run: |
+          GS="$GITHUB_WORKSPACE/wolfssl/scripts/gen-sbom"
+          if [ ! -f "$GS" ]; then
+            echo "have=no" >> "$GITHUB_OUTPUT"
+            echo "::notice::wolfssl scripts/gen-sbom not present on this ref; skipping SBOM generation."
+            exit 0
+          fi
+          echo "have=yes" >> "$GITHUB_OUTPUT"
+          HELP="$(python3 "$GS" --help 2>/dev/null)"
+          if echo "$HELP" | grep -q -- '--dep-wolfssl'; then
+            echo "dep_wolfssl=yes" >> "$GITHUB_OUTPUT"
+          else
+            echo "dep_wolfssl=no" >> "$GITHUB_OUTPUT"
+            echo "::notice::gen-sbom on this ref has no --dep-wolfssl; the wolfssl dependency + name-derived identity assertions will be skipped."
+          fi
+          if echo "$HELP" | grep -q -- '--dep-openssl'; then
+            echo "dep_openssl=yes" >> "$GITHUB_OUTPUT"
+          else
+            echo "dep_openssl=no" >> "$GITHUB_OUTPUT"
+            echo "::notice::gen-sbom on this ref has no --dep-openssl; the openssl dependency assertion will be skipped."
+          fi
+
+      - name: Resolve linked OpenSSL version
+        if: steps.gate.outputs.have == 'yes'
+        id: vers
+        run: |
+          ov=$(openssl version | awk '{print $2}')
+          echo "openssl=$ov" >> "$GITHUB_OUTPUT"
+          echo "linked openssl=$ov"
+
+      - name: Configure and build wolfengine
+        if: steps.gate.outputs.have == 'yes'
+        working-directory: wolfengine
+        run: |
+          autoreconf -ivf || ./autogen.sh
+          ./configure --with-wolfssl="$GITHUB_WORKSPACE/wolfssl-install" \
+              --with-openssl=/usr
+          make -j"$(nproc)"
+
+      - name: Generate SBOM
+        if: steps.gate.outputs.have == 'yes'
+        working-directory: wolfengine
+        run: |
+          make sbom \
+              WOLFSSL_DIR="$GITHUB_WORKSPACE/wolfssl" \
+              SBOM_OPENSSL_VERSION="${{ steps.vers.outputs.openssl }}"
+
+      - name: Outputs exist and SPDX validates
+        if: steps.gate.outputs.have == 'yes'
+        working-directory: wolfengine
+        run: |
+          ls wolfengine-*.cdx.json wolfengine-*.spdx.json wolfengine-*.spdx
+          pyspdxtools --infile wolfengine-*.spdx.json
+
+      - name: CycloneDX identity and licence
+        if: steps.gate.outputs.have == 'yes'
+        working-directory: wolfengine
+        run: |
+          python3 - <<'PY'
+          import glob, json
+          cdx = json.load(open(glob.glob('wolfengine-*.cdx.json')[0]))
+          assert cdx['bomFormat'] == 'CycloneDX', cdx.get('bomFormat')
+          assert cdx['specVersion'] == '1.6', cdx.get('specVersion')
+          m = cdx['metadata']['component']
+          assert m['name'] == 'wolfengine', m['name']
+          assert m['purl'].startswith('pkg:github/wolfSSL/wolfengine@'), m['purl']
+          # Default override must land as GPL-3.0-or-later (matches source headers).
+          ids = [l.get('license', {}).get('id') for l in m.get('licenses', [])]
+          assert 'GPL-3.0-or-later' in ids, ids
+          # Identity is the hashed library artifact.
+          assert {h['alg'] for h in m.get('hashes', [])}, 'no component hash'
+          print('CDX ok:', m['name'], m['purl'], ids)
+          PY
+
+      - name: Reproducible across two runs (SOURCE_DATE_EPOCH)
+        if: steps.gate.outputs.have == 'yes'
+        working-directory: wolfengine
+        run: |
+          rm -f wolfengine-*.cdx.json wolfengine-*.spdx.json wolfengine-*.spdx
+          SOURCE_DATE_EPOCH=1700000000 make sbom \
+              WOLFSSL_DIR="$GITHUB_WORKSPACE/wolfssl" \
+              SBOM_OPENSSL_VERSION="${{ steps.vers.outputs.openssl }}"
+          sha256sum wolfengine-*.cdx.json wolfengine-*.spdx.json > /tmp/a.sums
+          rm -f wolfengine-*.cdx.json wolfengine-*.spdx.json wolfengine-*.spdx
+          SOURCE_DATE_EPOCH=1700000000 make sbom \
+              WOLFSSL_DIR="$GITHUB_WORKSPACE/wolfssl" \
+              SBOM_OPENSSL_VERSION="${{ steps.vers.outputs.openssl }}"
+          sha256sum wolfengine-*.cdx.json wolfengine-*.spdx.json > /tmp/b.sums
+          diff /tmp/a.sums /tmp/b.sums
+
+      - name: wolfssl recorded as a dependency
+        if: steps.gate.outputs.have == 'yes' && steps.gate.outputs.dep_wolfssl == 'yes'
+        working-directory: wolfengine
+        run: |
+          python3 - <<'PY'
+          import glob, json
+          d = json.load(open(glob.glob('wolfengine-*.spdx.json')[0]))
+          assert 'wolfssl' in {p['name'] for p in d['packages']}, \
+              [p['name'] for p in d['packages']]
+          rels = [(r['spdxElementId'], r['relationshipType'],
+                   r['relatedSpdxElement']) for r in d['relationships']]
+          assert ('SPDXRef-Package-wolfengine', 'DEPENDS_ON',
+                  'SPDXRef-Package-wolfssl') in rels, rels
+          print('wolfssl dependency ok')
+          PY
+
+      - name: openssl recorded as a dependency
+        if: steps.gate.outputs.have == 'yes' && steps.gate.outputs.dep_openssl == 'yes'
+        working-directory: wolfengine
+        run: |
+          python3 - <<'PY'
+          import glob, json
+          d = json.load(open(glob.glob('wolfengine-*.spdx.json')[0]))
+          assert 'openssl' in {p['name'] for p in d['packages']}, \
+              [p['name'] for p in d['packages']]
+          rels = [(r['spdxElementId'], r['relationshipType'],
+                   r['relatedSpdxElement']) for r in d['relationships']]
+          assert ('SPDXRef-Package-wolfengine', 'DEPENDS_ON',
+                  'SPDXRef-Package-openssl') in rels, rels
+          print('openssl dependency ok')
+          PY
+
+      - name: Upload SBOM artefacts
+        if: always() && steps.gate.outputs.have == 'yes'
+        uses: actions/upload-artifact@v4
+        with:
+          name: wolfengine-sbom-${{ github.sha }}
+          path: |
+            wolfengine/wolfengine-*.cdx.json
+            wolfengine/wolfengine-*.spdx.json
+            wolfengine/wolfengine-*.spdx
+          if-no-files-found: warn
+          retention-days: 90

--- a/Makefile.am
+++ b/Makefile.am
@@ -47,3 +47,51 @@ AM_DISTCHECK_CONFIGURE_FLAGS=CPPFLAGS="-I@abs_top_srcdir@/include" --with-openss
 EXTRA_DIST += README.md \
               engine.conf \
               ChangeLog.md
+
+# ---------------------------------------------------------------------------
+# SBOM generation (CycloneDX + SPDX) via wolfssl's scripts/gen-sbom
+# ---------------------------------------------------------------------------
+# Requires WOLFSSL_DIR to point at a wolfssl checkout (for scripts/gen-sbom).
+# wolfEngine has no generated options.h of its own; feature flags come from the
+# installed wolfssl. WOLFSSL_INCLUDEDIR defaults to $(WOLFSSL_DIR)/include but
+# can be overridden if wolfssl's headers live elsewhere.
+WOLFSSL_DIR ?=
+WOLFSSL_INCLUDEDIR ?= $(WOLFSSL_DIR)/include
+PRODUCT      = wolfengine
+VERSION      = $(shell grep -m1 'AC_INIT' $(srcdir)/configure.ac | sed "s/.*\[//;s/\].*//")
+GEN_SBOM     = $(WOLFSSL_DIR)/scripts/gen-sbom
+
+SBOM_OUT_DIR = $(builddir)
+SBOM_CDX     = $(SBOM_OUT_DIR)/$(PRODUCT)-$(VERSION).cdx.json
+SBOM_SPDX_J  = $(SBOM_OUT_DIR)/$(PRODUCT)-$(VERSION).spdx.json
+SBOM_SPDX_TV = $(SBOM_OUT_DIR)/$(PRODUCT)-$(VERSION).spdx
+
+.PHONY: sbom install-sbom uninstall-sbom
+
+sbom: all
+	@if test -z "$(WOLFSSL_DIR)"; then \
+	    echo "ERROR: WOLFSSL_DIR not set. Usage: make sbom WOLFSSL_DIR=/path/to/wolfssl"; \
+	    exit 1; \
+	fi
+	@if test -z "$(PYTHON3)"; then \
+	    echo "ERROR: python3 not found in PATH."; exit 1; fi
+	$(MAKE) install DESTDIR=$(abs_builddir)/_sbom_stage
+	$(PYTHON3) $(GEN_SBOM) \
+	    --name $(PRODUCT) \
+	    --version $(VERSION) \
+	    --supplier "wolfSSL Inc." \
+	    --options-h $(WOLFSSL_INCLUDEDIR)/wolfssl/options.h \
+	    --lib `find $(abs_builddir)/_sbom_stage$(libdir) -name 'libwolfengine.so.*.*.*' | head -1`
+	rm -rf $(abs_builddir)/_sbom_stage
+
+install-sbom: sbom
+	$(MKDIR_P) $(DESTDIR)$(datadir)/doc/$(PRODUCT)
+	$(INSTALL_DATA) $(SBOM_CDX) $(SBOM_SPDX_J) $(SBOM_SPDX_TV) \
+	    $(DESTDIR)$(datadir)/doc/$(PRODUCT)/
+
+uninstall-sbom:
+	-rm -f $(DESTDIR)$(datadir)/doc/$(PRODUCT)/$(PRODUCT)-*.cdx.json
+	-rm -f $(DESTDIR)$(datadir)/doc/$(PRODUCT)/$(PRODUCT)-*.spdx.json
+	-rm -f $(DESTDIR)$(datadir)/doc/$(PRODUCT)/$(PRODUCT)-*.spdx
+
+uninstall-hook: uninstall-sbom

--- a/Makefile.am
+++ b/Makefile.am
@@ -68,6 +68,11 @@ SBOM_DEP_OPENSSL  = yes
 # (e.g. LicenseRef-wolfSSL-Commercial).
 SBOM_LICENSE_OVERRIDE ?= GPL-3.0-or-later
 
+# wolfEngine declares AC_CONFIG_HEADERS([include/config.h]) and carries its
+# feature macros (-DWE_HAVE_*, -DWE_NO_DYNAMIC_ENGINE, ...) in AM_CFLAGS, so
+# point the SBOM build-options capture at the real config header.
+SBOM_CONFIG_H = $(abs_builddir)/include/config.h
+
 EXTRA_DIST += scripts/sbom.am
 
 include scripts/sbom.am

--- a/Makefile.am
+++ b/Makefile.am
@@ -5,6 +5,7 @@ noinst_HEADERS =
 check_PROGRAMS =
 dist_noinst_SCRIPTS =
 DISTCLEANFILES =
+CLEANFILES =
 pkginclude_HEADERS =
 EXTRA_DIST =
 
@@ -48,50 +49,25 @@ EXTRA_DIST += README.md \
               engine.conf \
               ChangeLog.md
 
-# ---------------------------------------------------------------------------
-# SBOM generation (CycloneDX + SPDX) via wolfssl's scripts/gen-sbom
-# ---------------------------------------------------------------------------
-# Requires WOLFSSL_DIR to point at a wolfssl checkout (for scripts/gen-sbom).
-# wolfEngine has no generated options.h of its own; feature flags come from the
-# installed wolfssl. WOLFSSL_INCLUDEDIR defaults to $(WOLFSSL_DIR)/include but
-# can be overridden if wolfssl's headers live elsewhere.
-WOLFSSL_DIR ?=
-WOLFSSL_INCLUDEDIR ?= $(WOLFSSL_DIR)/include
-PRODUCT      = wolfengine
-VERSION      = $(shell grep -m1 'AC_INIT' $(srcdir)/configure.ac | sed "s/.*\[//;s/\].*//")
-GEN_SBOM     = $(WOLFSSL_DIR)/scripts/gen-sbom
+# SBOM generation (CRA compliance).  The recipe is shared across the wolfSSL
+# stack's autotools products in scripts/sbom.am; wolfEngine just declares what
+# it is (a libwolfengine shared library that links both wolfSSL and OpenSSL) and
+# includes it.  WOLFSSL_DIR must point to a wolfssl source tree containing
+# scripts/gen-sbom; it defaults to the --with-wolfssl location, which is an
+# install prefix, so for `make sbom` pass a source tree:
+# make sbom WOLFSSL_DIR=/path/to/wolfssl.
+SBOM_PKGNAME      = wolfengine
+SBOM_LICENSE_FILE = $(srcdir)/COPYING
+SBOM_DEP_WOLFSSL  = yes
+SBOM_DEP_OPENSSL  = yes
 
-SBOM_OUT_DIR = $(builddir)
-SBOM_CDX     = $(SBOM_OUT_DIR)/$(PRODUCT)-$(VERSION).cdx.json
-SBOM_SPDX_J  = $(SBOM_OUT_DIR)/$(PRODUCT)-$(VERSION).spdx.json
-SBOM_SPDX_TV = $(SBOM_OUT_DIR)/$(PRODUCT)-$(VERSION).spdx
+# wolfEngine is GPLv3-or-later (per the per-file source headers: "either version
+# 3 of the License, or (at your option) any later version") or commercial.  Pin
+# the header-accurate SPDX id here so the SBOM is correct regardless of the
+# gen-sbom version's licence detection; commercial licensees can override it
+# (e.g. LicenseRef-wolfSSL-Commercial).
+SBOM_LICENSE_OVERRIDE ?= GPL-3.0-or-later
 
-.PHONY: sbom install-sbom uninstall-sbom
+EXTRA_DIST += scripts/sbom.am
 
-sbom: all
-	@if test -z "$(WOLFSSL_DIR)"; then \
-	    echo "ERROR: WOLFSSL_DIR not set. Usage: make sbom WOLFSSL_DIR=/path/to/wolfssl"; \
-	    exit 1; \
-	fi
-	@if test -z "$(PYTHON3)"; then \
-	    echo "ERROR: python3 not found in PATH."; exit 1; fi
-	$(MAKE) install DESTDIR=$(abs_builddir)/_sbom_stage
-	$(PYTHON3) $(GEN_SBOM) \
-	    --name $(PRODUCT) \
-	    --version $(VERSION) \
-	    --supplier "wolfSSL Inc." \
-	    --options-h $(WOLFSSL_INCLUDEDIR)/wolfssl/options.h \
-	    --lib `find $(abs_builddir)/_sbom_stage$(libdir) -name 'libwolfengine.so.*.*.*' | head -1`
-	rm -rf $(abs_builddir)/_sbom_stage
-
-install-sbom: sbom
-	$(MKDIR_P) $(DESTDIR)$(datadir)/doc/$(PRODUCT)
-	$(INSTALL_DATA) $(SBOM_CDX) $(SBOM_SPDX_J) $(SBOM_SPDX_TV) \
-	    $(DESTDIR)$(datadir)/doc/$(PRODUCT)/
-
-uninstall-sbom:
-	-rm -f $(DESTDIR)$(datadir)/doc/$(PRODUCT)/$(PRODUCT)-*.cdx.json
-	-rm -f $(DESTDIR)$(datadir)/doc/$(PRODUCT)/$(PRODUCT)-*.spdx.json
-	-rm -f $(DESTDIR)$(datadir)/doc/$(PRODUCT)/$(PRODUCT)-*.spdx
-
-uninstall-hook: uninstall-sbom
+include scripts/sbom.am

--- a/README.md
+++ b/README.md
@@ -189,6 +189,34 @@ Visual Studio.
 
 Example programs using wolfEngine can be found in the `examples/` subdirectory.
 
+## SBOM / EU CRA Compliance
+
+wolfEngine generates a Software Bill of Materials (SBOM) in CycloneDX 1.6 and
+SPDX 2.3 formats to support compliance with the EU Cyber Resilience Act (CRA).
+
+```sh
+make sbom WOLFSSL_DIR=/path/to/wolfssl
+```
+
+Requires `python3` and `pyspdxtools` (`pip install spdx-tools`). `WOLFSSL_DIR`
+must point to a wolfssl source tree containing `scripts/gen-sbom` (branch
+`feat/sbom-embedded`, or `master` once wolfSSL/wolfssl#10343 merges).
+
+Output files in the build directory:
+
+| File | Format |
+|------|--------|
+| `wolfengine-1.4.0.cdx.json` | CycloneDX 1.6 |
+| `wolfengine-1.4.0.spdx.json` | SPDX 2.3 JSON |
+| `wolfengine-1.4.0.spdx` | SPDX 2.3 tag-value |
+
+```sh
+make install-sbom    # installs to $(datadir)/doc/wolfengine/
+make uninstall-sbom
+```
+
+For further CRA guidance see [wolfssl/doc/CRA.md](https://github.com/wolfSSL/wolfssl/blob/master/doc/CRA.md).
+
 ## Need Help?
 
 Please reach out to support@wolfssl.com for technical support. If you're

--- a/README.md
+++ b/README.md
@@ -193,6 +193,13 @@ Example programs using wolfEngine can be found in the `examples/` subdirectory.
 
 wolfEngine generates a Software Bill of Materials (SBOM) in CycloneDX 1.6 and
 SPDX 2.3 formats to support compliance with the EU Cyber Resilience Act (CRA).
+The SBOM records the configured build options, hashes the built `libwolfengine`
+library artifact (shared or static; ELF, Mach-O, or PE), and (with a
+sufficiently new `gen-sbom`) lists both wolfSSL and OpenSSL as dependencies so
+vulnerability scanners can associate wolfSSL and OpenSSL advisories with a
+wolfEngine deployment. Output is reproducible: set `SOURCE_DATE_EPOCH` (or
+build from a git checkout, which uses the last commit time) and repeated runs
+are byte-identical.
 
 ```sh
 make sbom WOLFSSL_DIR=/path/to/wolfssl
@@ -200,20 +207,35 @@ make sbom WOLFSSL_DIR=/path/to/wolfssl
 
 Requires `python3` and `pyspdxtools` (`pip install spdx-tools`). `WOLFSSL_DIR`
 must point to a wolfssl source tree containing `scripts/gen-sbom` (branch
-`feat/sbom-embedded`, or `master` once wolfSSL/wolfssl#10343 merges).
+`feat/sbom-embedded`, or `master` once wolfSSL/wolfssl#10343 merges); note that
+`--with-wolfssl` normally points at an install prefix, which does not ship
+`gen-sbom`, so pass a source tree here.
 
-Output files in the build directory:
+Output: `wolfengine-<version>.cdx.json`, `wolfengine-<version>.spdx.json`, `wolfengine-<version>.spdx`
 
-| File | Format |
-|------|--------|
-| `wolfengine-1.4.0.cdx.json` | CycloneDX 1.6 |
-| `wolfengine-1.4.0.spdx.json` | SPDX 2.3 JSON |
-| `wolfengine-1.4.0.spdx` | SPDX 2.3 tag-value |
+Optional overrides:
+
+- `SBOM_LICENSE_OVERRIDE` - SPDX expression to use instead of the licence
+  parsed from `COPYING` (e.g. `LicenseRef-wolfSSL-Commercial` for commercial
+  licensees). Defaults to `GPL-3.0-or-later` (the per-file header licence).
+- `SBOM_LICENSE_TEXT` - path to the licence text for any `LicenseRef-*` used in
+  `SBOM_LICENSE_OVERRIDE` (required by SPDX 2.3).
+- `SBOM_WOLFSSL_VERSION` - version recorded for the wolfSSL dependency;
+  auto-detected from `WOLFSSL_DIR/wolfssl/version.h` (or wolfSSL's `pkg-config`
+  entry) when unset.
+- `SBOM_OPENSSL_VERSION` - version recorded for the OpenSSL dependency;
+  resolved via OpenSSL's `pkg-config` entry when unset.
 
 ```sh
 make install-sbom    # installs to $(datadir)/doc/wolfengine/
 make uninstall-sbom
 ```
+
+Note: recording wolfSSL and OpenSSL as dependencies and emitting
+wolfEngine-specific project URLs require the `gen-sbom` from
+wolfSSL/wolfssl#10343. Against an older `gen-sbom`, `make sbom` still succeeds
+and produces a valid SBOM, but omits the dependency entries and inherits
+wolfSSL's project URLs.
 
 For further CRA guidance see [wolfssl/doc/CRA.md](https://github.com/wolfSSL/wolfssl/blob/master/doc/CRA.md).
 

--- a/configure.ac
+++ b/configure.ac
@@ -721,9 +721,15 @@ AC_SUBST([AM_CPPFLAGS])
 AC_SUBST([AM_CFLAGS])
 AC_SUBST([AM_LDFLAGS])
 
-# SBOM generation tools
-AC_CHECK_PROG([PYTHON3], [python3], [python3])
-AC_CHECK_PROG([PYSPDXTOOLS], [pyspdxtools], [pyspdxtools])
+# Tools used by the SBOM targets (see scripts/sbom.am `make sbom`).  GIT is used
+# only to derive SOURCE_DATE_EPOCH for reproducible SBOM output; all three are
+# optional and the target reports a clear error when a required one is missing.
+AC_PATH_PROG([PYTHON3], [python3])
+AC_PATH_PROG([PYSPDXTOOLS], [pyspdxtools])
+AC_PATH_PROG([GIT], [git])
+AC_SUBST([PYTHON3])
+AC_SUBST([PYSPDXTOOLS])
+AC_SUBST([GIT])
 
 AC_CONFIG_FILES([Makefile
        rpm/spec])

--- a/configure.ac
+++ b/configure.ac
@@ -721,6 +721,10 @@ AC_SUBST([AM_CPPFLAGS])
 AC_SUBST([AM_CFLAGS])
 AC_SUBST([AM_LDFLAGS])
 
+# SBOM generation tools
+AC_CHECK_PROG([PYTHON3], [python3], [python3])
+AC_CHECK_PROG([PYSPDXTOOLS], [pyspdxtools], [pyspdxtools])
+
 AC_CONFIG_FILES([Makefile
        rpm/spec])
 AC_OUTPUT

--- a/scripts/sbom.am
+++ b/scripts/sbom.am
@@ -20,6 +20,12 @@
 #                       (e.g. $(srcdir)/LICENSING).
 #
 # Optional (defaults shown):
+#   SBOM_OPTIONS_H      Path to a product-generated options header (e.g.
+#                       wolfMQTT's $(builddir)/wolfmqtt/options.h) that records
+#                       the enabled build macros.  Set this for products whose
+#                       feature flags are NOT in config.h (no AC_DEFINE); when
+#                       unset the recipe derives the macros from the compiler +
+#                       config.h.  Default: unset.
 #   SBOM_ARTIFACT       lib | bin - which build output to hash.  Default: lib.
 #   SBOM_LIB_STEM       Library basename w/o extension.  Default: lib$(SBOM_PKGNAME).
 #   SBOM_BIN_NAME       Program name when SBOM_ARTIFACT = bin.  Default: $(SBOM_PKGNAME).
@@ -99,8 +105,9 @@ CLEANFILES += $(SBOM_CDX) $(SBOM_SPDX) $(SBOM_SPDX_TV)
 
 # Stage a `make install` into a private tree, discover the installed artifact
 # (shared/static library or program; ELF/Mach-O/PE), hash it, capture the
-# configured build macros (AM_CPPFLAGS/AM_CFLAGS/CFLAGS + config.h; some
-# products carry their feature -D flags in AM_CFLAGS rather than AM_CPPFLAGS),
+# configured build macros (from SBOM_OPTIONS_H if set, else AM_CPPFLAGS/
+# AM_CFLAGS/CFLAGS + config.h; some products carry their feature -D flags in
+# AM_CFLAGS rather than AM_CPPFLAGS, and some outside config.h entirely),
 # generate SPDX+CDX, validate
 # the SPDX, then convert to tag-value.  The staging tree and temp defines file
 # are removed unconditionally via `trap`, even on failure.  SOURCE_DATE_EPOCH is
@@ -143,10 +150,14 @@ sbom:
 	    exit 1; \
 	fi; \
 	echo "SBOM: hashing $$sbom_art"; \
-	$(CC) -dM -E $(DEFAULT_INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) \
-	    $(AM_CFLAGS) $(CFLAGS) \
-	    $(if $(wildcard $(SBOM_CONFIG_H)),-include $(SBOM_CONFIG_H)) \
-	    -x c /dev/null > "$$_defines"; \
+	opts_h="$(SBOM_OPTIONS_H)"; \
+	if test -z "$$opts_h"; then \
+	    opts_h="$$_defines"; \
+	    $(CC) -dM -E $(DEFAULT_INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) \
+	        $(AM_CFLAGS) $(CFLAGS) \
+	        $(if $(wildcard $(SBOM_CONFIG_H)),-include $(SBOM_CONFIG_H)) \
+	        -x c /dev/null > "$$_defines"; \
+	fi; \
 	if test -z "$${SOURCE_DATE_EPOCH:-}" && test -n "$(GIT)" && \
 	   $(GIT) -C "$(srcdir)" rev-parse --git-dir >/dev/null 2>&1; then \
 	    sde=`$(GIT) -C "$(srcdir)" log -1 --format=%ct 2>/dev/null`; \
@@ -190,7 +201,7 @@ sbom:
 	    --version $(PACKAGE_VERSION) \
 	    --supplier "wolfSSL Inc." \
 	    --license-file $(SBOM_LICENSE_FILE) \
-	    --options-h "$$_defines" \
+	    --options-h "$$opts_h" \
 	    --lib "$$sbom_art" \
 	    $$dep_args \
 	    $(if $(SBOM_LICENSE_OVERRIDE),--license-override '$(SBOM_LICENSE_OVERRIDE)') \

--- a/scripts/sbom.am
+++ b/scripts/sbom.am
@@ -1,0 +1,196 @@
+# scripts/sbom.am - shared Automake recipe for CRA-compliant SBOM generation.
+#
+# One generator (gen-sbom) does the work; each product just describes itself and
+# includes this fragment.  It is deliberately product-agnostic: a Makefile.am
+# sets a few variables (below) and does `include scripts/sbom.am` to get the
+# `sbom`, `install-sbom` and `uninstall-sbom` targets.
+#
+# The canonical copy lives in the wolfSSL repository (scripts/sbom.am); keep
+# product copies in sync.  gen-sbom is taken from a vendored scripts/gen-sbom
+# if a product ships one (used automatically), otherwise from a wolfSSL source
+# tree via WOLFSSL_DIR.  wolfSSH uses the WOLFSSL_DIR route; vendoring gen-sbom
+# for fully offline tarball builds can be added later with no change here.
+#
+# ---------------------------------------------------------------------------
+# The including Makefile.am MUST set, before `include scripts/sbom.am`:
+#   SBOM_PKGNAME        Product name recorded in the SBOM (e.g. wolfssh).  Drives
+#                       the output filenames and gen-sbom --name.
+#   SBOM_LICENSE_FILE   Path to the product's LICENSING file
+#                       (e.g. $(srcdir)/LICENSING).
+#
+# Optional (defaults shown):
+#   SBOM_ARTIFACT       lib | bin - which build output to hash.  Default: lib.
+#   SBOM_LIB_STEM       Library basename w/o extension.  Default: lib$(SBOM_PKGNAME).
+#   SBOM_BIN_NAME       Program name when SBOM_ARTIFACT = bin.  Default: $(SBOM_PKGNAME).
+#   SBOM_DEP_WOLFSSL    yes | no - record wolfSSL as a dependency.  Default: no.
+#   SBOM_DEP_OPENSSL    yes | no - record OpenSSL as a dependency (wolfProvider /
+#                       wolfEngine).  Default: no.
+#   SBOM_LICENSE_OVERRIDE  SPDX expression to record instead of the licence
+#                       detected from SBOM_LICENSE_FILE.
+#   SBOM_LICENSE_TEXT   Path to licence text for any LicenseRef-* used in
+#                       SBOM_LICENSE_OVERRIDE (required by SPDX 2.3).
+#   SBOM_WOLFSSL_VERSION   Version recorded for the wolfSSL dependency;
+#                       auto-detected from WOLFSSL_DIR/wolfssl/version.h when unset.
+#   SBOM_OPENSSL_VERSION   Version recorded for the OpenSSL dependency;
+#                       gen-sbom resolves it via pkg-config when unset.
+#
+# The wolfSSL/OpenSSL dependency flags are feature-detected against gen-sbom
+# --help, so a product wired for them still produces a valid SBOM (with a NOTE)
+# against a gen-sbom that predates the flag.
+#
+# gen-sbom is located at $(srcdir)/scripts/gen-sbom if vendored, else at
+# $(WOLFSSL_DIR)/scripts/gen-sbom.  python3, pyspdxtools and git come from
+# configure (AC_PATH_PROG); git is used only to derive SOURCE_DATE_EPOCH.
+# ---------------------------------------------------------------------------
+
+SBOM_ARTIFACT ?= lib
+SBOM_LIB_STEM ?= lib$(SBOM_PKGNAME)
+SBOM_BIN_NAME ?= $(SBOM_PKGNAME)
+SBOM_DEP_WOLFSSL ?= no
+SBOM_DEP_OPENSSL ?= no
+
+SBOM_CDX     = $(SBOM_PKGNAME)-$(PACKAGE_VERSION).cdx.json
+SBOM_SPDX    = $(SBOM_PKGNAME)-$(PACKAGE_VERSION).spdx.json
+SBOM_SPDX_TV = $(SBOM_PKGNAME)-$(PACKAGE_VERSION).spdx
+sbomdir      = $(datadir)/doc/$(PACKAGE)
+
+# Prefer a vendored gen-sbom; fall back to an external wolfSSL source tree.
+# The fallback is $(wildcard)-guarded and only consulted when WOLFSSL_DIR is
+# set, so an unset WOLFSSL_DIR leaves SBOM_GEN empty (and the sbom recipe's
+# `test -f` prints the "set WOLFSSL_DIR" error) rather than resolving to an
+# absolute /scripts/gen-sbom that could run an unrelated host script.
+SBOM_GEN = $(firstword $(wildcard $(srcdir)/scripts/gen-sbom) \
+                       $(if $(WOLFSSL_DIR),$(wildcard $(WOLFSSL_DIR)/scripts/gen-sbom)))
+
+# Library artifact search order (versioned first) covering ELF, Mach-O and PE.
+# Windows import libs (.lib) come with and without the "lib" prefix.
+SBOM_LIB_GLOBS = \
+    $(SBOM_LIB_STEM).so.[0-9]* \
+    $(SBOM_LIB_STEM).so \
+    $(SBOM_LIB_STEM).[0-9]*.dylib \
+    $(SBOM_LIB_STEM).dylib \
+    $(SBOM_LIB_STEM).dll \
+    $(SBOM_LIB_STEM).dll.a \
+    $(SBOM_LIB_STEM).lib \
+    $(SBOM_PKGNAME).lib \
+    $(SBOM_LIB_STEM).a
+
+# Automake requires CLEANFILES to be initialised with `=` before `+=`; the
+# including Makefile.am must declare `CLEANFILES =` (typically in its primaries
+# init block) before `include scripts/sbom.am`.
+CLEANFILES += $(SBOM_CDX) $(SBOM_SPDX) $(SBOM_SPDX_TV)
+
+.PHONY: sbom install-sbom uninstall-sbom
+
+# Stage a `make install` into a private tree, discover the installed artifact
+# (shared/static library or program; ELF/Mach-O/PE), hash it, capture the
+# configured build macros (AM_CPPFLAGS + config.h), generate SPDX+CDX, validate
+# the SPDX, then convert to tag-value.  The staging tree and temp defines file
+# are removed unconditionally via `trap`, even on failure.  SOURCE_DATE_EPOCH is
+# honoured for reproducible output (defaults to the last git commit time).
+sbom:
+	@test -n "$(PYTHON3)" || { \
+	    echo "ERROR: 'python3' not found in PATH. Cannot generate SBOM."; \
+	    exit 1; }
+	@test -n "$(PYSPDXTOOLS)" || { \
+	    echo "ERROR: 'pyspdxtools' not found (pip install spdx-tools)."; \
+	    exit 1; }
+	@test -f "$(SBOM_GEN)" || { \
+	    echo "ERROR: gen-sbom not found. Vendor scripts/gen-sbom, or re-run:"; \
+	    echo "       make sbom WOLFSSL_DIR=/path/to/wolfssl"; \
+	    exit 1; }
+	@rm -rf $(abs_builddir)/_sbom_staging
+	@set -e; \
+	_defines=`mktemp $(abs_builddir)/_sbom_defines.XXXXXX`; \
+	trap 'rm -rf $(abs_builddir)/_sbom_staging "$$_defines"' EXIT INT TERM HUP; \
+	$(MAKE) install DESTDIR=$(abs_builddir)/_sbom_staging; \
+	sbom_art=""; \
+	if test "$(SBOM_ARTIFACT)" = bin; then \
+	    for art in \
+	        "$(abs_builddir)/_sbom_staging$(bindir)/$(SBOM_BIN_NAME)" \
+	        "$(abs_builddir)/_sbom_staging$(bindir)/$(SBOM_BIN_NAME)".exe; do \
+	        if test -f "$$art"; then sbom_art="$$art"; break; fi; \
+	    done; \
+	else \
+	    for art in \
+	        $(addprefix "$(abs_builddir)/_sbom_staging$(libdir)"/,$(SBOM_LIB_GLOBS)) \
+	        $(addprefix "$(abs_builddir)/_sbom_staging$(bindir)"/,$(SBOM_LIB_STEM).dll $(SBOM_PKGNAME).dll); do \
+	        if test -f "$$art"; then sbom_art="$$art"; break; fi; \
+	    done; \
+	fi; \
+	if test -z "$$sbom_art"; then \
+	    echo ""; \
+	    echo "ERROR: no installed $(SBOM_PKGNAME) artifact found for SBOM."; \
+	    echo "       (configure with --enable-shared or --enable-static)"; \
+	    echo ""; \
+	    exit 1; \
+	fi; \
+	echo "SBOM: hashing $$sbom_art"; \
+	$(CC) -dM -E $(DEFAULT_INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) \
+	    $(if $(wildcard $(abs_builddir)/config.h),-include $(abs_builddir)/config.h) \
+	    -x c /dev/null > "$$_defines"; \
+	if test -z "$${SOURCE_DATE_EPOCH:-}" && test -n "$(GIT)" && \
+	   $(GIT) -C "$(srcdir)" rev-parse --git-dir >/dev/null 2>&1; then \
+	    sde=`$(GIT) -C "$(srcdir)" log -1 --format=%ct 2>/dev/null`; \
+	    if test -n "$$sde"; then SOURCE_DATE_EPOCH="$$sde"; export SOURCE_DATE_EPOCH; fi; \
+	fi; \
+	dep_args=""; \
+	if test "$(SBOM_DEP_WOLFSSL)" = yes; then \
+	    if $(PYTHON3) "$(SBOM_GEN)" --help 2>/dev/null \
+	        | $(GREP) -q -- '--dep-wolfssl'; then \
+	        dep_args="$$dep_args --dep-wolfssl yes"; \
+	        wv="$(SBOM_WOLFSSL_VERSION)"; \
+	        if test -z "$$wv" && test -f "$(WOLFSSL_DIR)/wolfssl/version.h"; then \
+	            wv=`sed -n 's/.*LIBWOLFSSL_VERSION_STRING[ \t]*"\([^"]*\)".*/\1/p' \
+	                "$(WOLFSSL_DIR)/wolfssl/version.h"`; \
+	        fi; \
+	        if test -n "$$wv"; then \
+	            dep_args="$$dep_args --dep-version wolfssl=$$wv"; \
+	        fi; \
+	    else \
+	        echo "NOTE: this gen-sbom has no --dep-wolfssl support, so the SBOM"; \
+	        echo "      will not list wolfssl as a dependency component. That"; \
+	        echo "      support is added by wolfSSL/wolfssl#10343; until it merges"; \
+	        echo "      to wolfssl master, point WOLFSSL_DIR at that PR's branch"; \
+	        echo "      to enable it. The generated SBOM is valid either way."; \
+	    fi; \
+	fi; \
+	if test "$(SBOM_DEP_OPENSSL)" = yes; then \
+	    if $(PYTHON3) "$(SBOM_GEN)" --help 2>/dev/null \
+	        | $(GREP) -q -- '--dep-openssl'; then \
+	        dep_args="$$dep_args --dep-openssl yes"; \
+	        if test -n "$(SBOM_OPENSSL_VERSION)"; then \
+	            dep_args="$$dep_args --dep-version openssl=$(SBOM_OPENSSL_VERSION)"; \
+	        fi; \
+	    else \
+	        echo "NOTE: this gen-sbom has no --dep-openssl support; openssl will"; \
+	        echo "      not be listed as a dependency component."; \
+	    fi; \
+	fi; \
+	$(PYTHON3) "$(SBOM_GEN)" \
+	    --name $(SBOM_PKGNAME) \
+	    --version $(PACKAGE_VERSION) \
+	    --supplier "wolfSSL Inc." \
+	    --license-file $(SBOM_LICENSE_FILE) \
+	    --options-h "$$_defines" \
+	    --lib "$$sbom_art" \
+	    $$dep_args \
+	    $(if $(SBOM_LICENSE_OVERRIDE),--license-override '$(SBOM_LICENSE_OVERRIDE)') \
+	    $(if $(SBOM_LICENSE_TEXT),--license-text '$(SBOM_LICENSE_TEXT)') \
+	    --cdx-out $(abs_builddir)/$(SBOM_CDX) \
+	    --spdx-out $(abs_builddir)/$(SBOM_SPDX); \
+	$(PYSPDXTOOLS) --infile $(abs_builddir)/$(SBOM_SPDX) \
+	    --outfile $(abs_builddir)/$(SBOM_SPDX_TV)
+
+install-sbom: sbom
+	$(MKDIR_P) $(DESTDIR)$(sbomdir)
+	$(INSTALL_DATA) $(SBOM_CDX) $(DESTDIR)$(sbomdir)/
+	$(INSTALL_DATA) $(SBOM_SPDX) $(DESTDIR)$(sbomdir)/
+	$(INSTALL_DATA) $(SBOM_SPDX_TV) $(DESTDIR)$(sbomdir)/
+
+uninstall-sbom:
+	-rm -f $(DESTDIR)$(sbomdir)/$(SBOM_CDX)
+	-rm -f $(DESTDIR)$(sbomdir)/$(SBOM_SPDX)
+	-rm -f $(DESTDIR)$(sbomdir)/$(SBOM_SPDX_TV)
+
+uninstall-hook: uninstall-sbom

--- a/scripts/sbom.am
+++ b/scripts/sbom.am
@@ -5,11 +5,12 @@
 # sets a few variables (below) and does `include scripts/sbom.am` to get the
 # `sbom`, `install-sbom` and `uninstall-sbom` targets.
 #
-# The canonical copy lives in the wolfSSL repository (scripts/sbom.am); keep
-# product copies in sync.  gen-sbom is taken from a vendored scripts/gen-sbom
-# if a product ships one (used automatically), otherwise from a wolfSSL source
-# tree via WOLFSSL_DIR.  wolfSSH uses the WOLFSSL_DIR route; vendoring gen-sbom
-# for fully offline tarball builds can be added later with no change here.
+# This is the canonical copy (wolfSSL repository, scripts/sbom.am); product
+# repositories vendor a copy of it and must be kept in sync with this file.
+# gen-sbom is taken from a vendored scripts/gen-sbom if a product ships one
+# (used automatically), otherwise from a wolfSSL source tree via WOLFSSL_DIR.
+# Products such as wolfSSH use the WOLFSSL_DIR route; vendoring gen-sbom for
+# fully offline tarball builds can be added later with no change here.
 #
 # ---------------------------------------------------------------------------
 # The including Makefile.am MUST set, before `include scripts/sbom.am`:
@@ -33,6 +34,13 @@
 #                       auto-detected from WOLFSSL_DIR/wolfssl/version.h when unset.
 #   SBOM_OPENSSL_VERSION   Version recorded for the OpenSSL dependency;
 #                       gen-sbom resolves it via pkg-config when unset.
+#   SBOM_CONFIG_H       Path to the configure-generated config header to
+#                       force-include when capturing the configured build
+#                       macros.  Products whose AC_CONFIG_HEADERS lives in a
+#                       subdirectory MUST override this so config.h defines are
+#                       captured (e.g. wolfEngine: $(abs_builddir)/include/config.h;
+#                       wolfCLU: $(abs_builddir)/src/config.h).
+#                       Default: $(abs_builddir)/config.h.
 #
 # The wolfSSL/OpenSSL dependency flags are feature-detected against gen-sbom
 # --help, so a product wired for them still produces a valid SBOM (with a NOTE)
@@ -41,6 +49,10 @@
 # gen-sbom is located at $(srcdir)/scripts/gen-sbom if vendored, else at
 # $(WOLFSSL_DIR)/scripts/gen-sbom.  python3, pyspdxtools and git come from
 # configure (AC_PATH_PROG); git is used only to derive SOURCE_DATE_EPOCH.
+#
+# NOTE: this fragment requires GNU make.  It uses GNU conditional assignment
+# (?=) and the GNU make functions $(wildcard), $(if), $(firstword) and
+# $(addprefix); under a non-GNU make the SBOM targets will not work.
 # ---------------------------------------------------------------------------
 
 SBOM_ARTIFACT ?= lib
@@ -48,11 +60,14 @@ SBOM_LIB_STEM ?= lib$(SBOM_PKGNAME)
 SBOM_BIN_NAME ?= $(SBOM_PKGNAME)
 SBOM_DEP_WOLFSSL ?= no
 SBOM_DEP_OPENSSL ?= no
+SBOM_CONFIG_H ?= $(abs_builddir)/config.h
 
 SBOM_CDX     = $(SBOM_PKGNAME)-$(PACKAGE_VERSION).cdx.json
 SBOM_SPDX    = $(SBOM_PKGNAME)-$(PACKAGE_VERSION).spdx.json
 SBOM_SPDX_TV = $(SBOM_PKGNAME)-$(PACKAGE_VERSION).spdx
-sbomdir      = $(datadir)/doc/$(PACKAGE)
+# Use Automake's $(docdir) so a user's --docdir override is honoured (this
+# equals $(datadir)/doc/$(PACKAGE) by default).
+sbomdir      = $(docdir)
 
 # Prefer a vendored gen-sbom; fall back to an external wolfSSL source tree.
 # The fallback is $(wildcard)-guarded and only consulted when WOLFSSL_DIR is
@@ -84,7 +99,9 @@ CLEANFILES += $(SBOM_CDX) $(SBOM_SPDX) $(SBOM_SPDX_TV)
 
 # Stage a `make install` into a private tree, discover the installed artifact
 # (shared/static library or program; ELF/Mach-O/PE), hash it, capture the
-# configured build macros (AM_CPPFLAGS + config.h), generate SPDX+CDX, validate
+# configured build macros (AM_CPPFLAGS/AM_CFLAGS/CFLAGS + config.h; some
+# products carry their feature -D flags in AM_CFLAGS rather than AM_CPPFLAGS),
+# generate SPDX+CDX, validate
 # the SPDX, then convert to tag-value.  The staging tree and temp defines file
 # are removed unconditionally via `trap`, even on failure.  SOURCE_DATE_EPOCH is
 # honoured for reproducible output (defaults to the last git commit time).
@@ -127,7 +144,8 @@ sbom:
 	fi; \
 	echo "SBOM: hashing $$sbom_art"; \
 	$(CC) -dM -E $(DEFAULT_INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) \
-	    $(if $(wildcard $(abs_builddir)/config.h),-include $(abs_builddir)/config.h) \
+	    $(AM_CFLAGS) $(CFLAGS) \
+	    $(if $(wildcard $(SBOM_CONFIG_H)),-include $(SBOM_CONFIG_H)) \
 	    -x c /dev/null > "$$_defines"; \
 	if test -z "$${SOURCE_DATE_EPOCH:-}" && test -n "$(GIT)" && \
 	   $(GIT) -C "$(srcdir)" rev-parse --git-dir >/dev/null 2>&1; then \
@@ -141,7 +159,7 @@ sbom:
 	        dep_args="$$dep_args --dep-wolfssl yes"; \
 	        wv="$(SBOM_WOLFSSL_VERSION)"; \
 	        if test -z "$$wv" && test -f "$(WOLFSSL_DIR)/wolfssl/version.h"; then \
-	            wv=`sed -n 's/.*LIBWOLFSSL_VERSION_STRING[ \t]*"\([^"]*\)".*/\1/p' \
+	            wv=`sed -n 's/.*LIBWOLFSSL_VERSION_STRING[[:space:]]*"\([^"]*\)".*/\1/p' \
 	                "$(WOLFSSL_DIR)/wolfssl/version.h"`; \
 	        fi; \
 	        if test -n "$$wv"; then \
@@ -193,4 +211,8 @@ uninstall-sbom:
 	-rm -f $(DESTDIR)$(sbomdir)/$(SBOM_SPDX)
 	-rm -f $(DESTDIR)$(sbomdir)/$(SBOM_SPDX_TV)
 
+# SBOM install is intentionally opt-in (`make install-sbom`), so `make install`
+# does NOT place SBOM files.  uninstall-sbom is still chained into the standard
+# `make uninstall` via uninstall-hook so a prior `make install-sbom` is cleaned
+# up; it uses `rm -f`, so it is a harmless no-op when no SBOM was installed.
 uninstall-hook: uninstall-sbom


### PR DESCRIPTION
## Summary

- Adds `make sbom`, `make install-sbom`, and `make uninstall-sbom` targets to wolfEngine's autotools build for EU CRA compliance evidence (CycloneDX 1.6 + SPDX 2.3 output)
- Adds `AC_CHECK_PROG` checks for `python3` and `pyspdxtools` in `configure.ac`

## Usage

```sh
make sbom WOLFSSL_DIR=/path/to/wolfssl
# produces: wolfengine-1.4.0.cdx.json  wolfengine-1.4.0.spdx.json  wolfengine-1.4.0.spdx
pyspdxtools --infile wolfengine-1.4.0.spdx.json   # must pass

make install-sbom   # installs to $(datadir)/doc/wolfengine/
make uninstall-sbom
```

`WOLFSSL_DIR` must point to a wolfssl checkout containing `scripts/gen-sbom` (branch `feat/sbom-embedded`, or `master` once wolfSSL/wolfssl#10343 merges).

## Notes

- wolfEngine has no generated `options.h`; feature flags come from the installed wolfssl. `--options-h` is read from `$(WOLFSSL_INCLUDEDIR)/wolfssl/options.h` (defaults to `$(WOLFSSL_DIR)/include`; override with `make sbom WOLFSSL_INCLUDEDIR=...` if wolfssl headers live elsewhere)
- wolfEngine's libtool version-info `1:4:0` produces `libwolfengine.so.1.0.4`, not `libwolfengine.so.1.4.0` — the staged `.so` is located with `find` rather than a hardcoded version suffix
- `uninstall-hook` dependency ensures `make uninstall` removes SBOM files